### PR TITLE
Make app ready for more translation and adding Thai language

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -83,10 +83,10 @@
 
         <CommandBar x:Name="CommandBar2" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False"  HorizontalAlignment="Right" Grid.RowSpan="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Margin="0,33,0,0">
             <CommandBar.SecondaryCommands>
-                <AppBarButton x:Name="CmdFocusMode" Click="CmdFocusMode_Click"  Icon="Caption" Label="Focus Mode" Width="Auto"/>
-                <AppBarButton x:Name="CmdShare" Label="Share"  Width="Auto" MinWidth="40" Icon="Share" Click="CmdShare_Click" ToolTipService.ToolTip="Share the file you are working on."/>
-                <AppBarButton x:Name="CmdReview" Icon="SolidStar" Label="Review" Click="CmdReview_Click" Width="Auto"/>
-                <AppBarButton x:Name="CmdSettings" Icon="Setting" Label="Settings" Width="Auto" Visibility="Visible" Click="CmdSettings_Click" ToolTipService.ToolTip="Settings"/>
+                <AppBarButton x:Name="CmdFocusMode" x:Uid="CmdFocusMode" Click="CmdFocusMode_Click"  Icon="Caption" Label="Focus Mode" Width="Auto"/>
+                <AppBarButton x:Name="CmdShare" x:Uid="CmdShare" Label="Share"  Width="Auto" MinWidth="40" Icon="Share" Click="CmdShare_Click" ToolTipService.ToolTip="Share the file you are working on."/>
+                <AppBarButton x:Name="CmdReview" x:Uid="CmdReview" Icon="SolidStar" Label="Review" Click="CmdReview_Click" Width="Auto"/>
+                <AppBarButton x:Name="CmdSettings" x:Uid="CmdSettings" Icon="Setting" Label="Settings" Width="Auto" Visibility="Visible" Click="CmdSettings_Click" ToolTipService.ToolTip="Settings"/>
             </CommandBar.SecondaryCommands>
             <AppBarButton x:Name="CmdUndo" Label="Undo" x:Uid="CmdUndo" Width="Auto" MinWidth="40" Icon="Undo" Visibility="Visible"  Click="CmdUndo_Click" ToolTipService.ToolTip="Undo (Ctrl+Z)"/>
             <AppBarButton x:Name="CmdRedo" Label="Redo" x:Uid="CmdRedo" Width="Auto" MinWidth="40" Icon="Redo" Visibility="Visible" Click="CmdRedo_Click" ToolTipService.ToolTip="Redo (Ctrl+Y)"/>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -133,10 +133,10 @@
                             <ScrollViewer x:Name="SettingsTab1SV" Height="200">
                                 <Grid Height="340">
                                     <TextBlock Text="Launch Mode" x:Uid="GeneralLaunchMode" Margin="0,10,23,87" TextWrapping="Wrap"/>
-                                    <ComboBox Margin="0,35,0,0" x:Uid="GeneralLaunchMode" PlaceholderText="Default" SelectionChanged="LaunchOptions_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="LaunchOptions" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="125" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
-                                        <x:String>Default</x:String>
-                                        <x:String>On Top</x:String>
-                                        <x:String>Focus Mode</x:String>
+                                    <ComboBox Margin="0,35,0,0" x:Uid="GeneralLaunchModeCombobox" PlaceholderText="Default" SelectionChanged="LaunchOptions_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="LaunchOptions" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="125" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
+                                        <ComboBoxItem Content="Default" Tag="Default" x:Uid="LaunchModeDefault" x:Name="LaunchModeDefault"/>
+                                        <ComboBoxItem Content="On Top" Tag="On Top" x:Uid="LaunchModeOnTop" x:Name="LaunchModeOnTop"/>
+                                        <ComboBoxItem Content="Focus Mode" Tag="Focus Mode" x:Uid="LaunchModeFocus" x:Name="LaunchModeFocus"/>
                                     </ComboBox>
                                     <TextBlock x:Uid="GeneralDefaultType" Text="Default File Type" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Segoe UI"/>
                                     <ComboBox Margin="0,105,0,0" PlaceholderText=".rtf" SelectionChanged="DefaultFileType_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
@@ -184,14 +184,14 @@
                                     <x:String>72</x:String>
                                 </ComboBox>
                                 <TextBlock x:Uid="DefaultFontColor" Text="Default Font Color" Margin="0,135,0,0" TextWrapping="Wrap"/>
-                                <ComboBox Margin="0,160,0,0" x:Name="DefaultFontColor" SelectionChanged="DefaultFontColor_SelectionChanged" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Black" Width="139" BorderThickness="1,1,1,1">
-                                    <x:String>Black</x:String>
-                                    <x:String>White</x:String>
-                                    <x:String>SkyBlue</x:String>
-                                    <x:String>LightGreen</x:String>
-                                    <x:String>LightPink</x:String>
-                                    <x:String>LightYellow</x:String>
-                                    <x:String>LightSalmon</x:String>
+                                <ComboBox Margin="0,160,0,0" x:Name="DefaultFontColor" x:Uid="DefaultFontColorCombobox" SelectionChanged="DefaultFontColor_SelectionChanged" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Black" Width="139" BorderThickness="1,1,1,1">
+                                    <ComboBoxItem Content="Black" Tag="Black" x:Uid="FontColorBlack" x:Name="FontColorBlack"/>
+                                    <ComboBoxItem Content="White" Tag="White" x:Uid="FontColorWhite" x:Name="FontColorWhite"/>
+                                    <ComboBoxItem Content="SkyBlue" Tag="SkyBlue" x:Uid="FontColorSkyBlue" x:Name="FontColorSkyBlue"/>
+                                    <ComboBoxItem Content="LightGreen" Tag="LightGreen" x:Uid="FontColorLightGreen" x:Name="FontColorLightGreen"/>
+                                    <ComboBoxItem Content="LightPink" Tag="LightPink" x:Uid="FontColorLightPink" x:Name="FontColorLightPink"/>
+                                    <ComboBoxItem Content="LightYellow" Tag="LightYellow" x:Uid="FontColorLightYellow" x:Name="FontColorLightYellow"/>
+                                    <ComboBoxItem Content="LightSalmon" Tag="LightSalmon" x:Uid="FontColorLightSalmon" x:Name="FontColorLightSalmon"/>
                                 </ComboBox>
                             </Grid>
                         </PivotItem>
@@ -247,13 +247,13 @@
             <AppBarButton x:Name="TextColor" x:Uid="TextColor" Width="40" Icon="FontColor" ToolTipService.ToolTip="Font Color">
                 <AppBarButton.Flyout>
                     <MenuFlyout>
-                        <MenuFlyoutItem x:Name="Black" Text="Black" Click="Black_Click" />
-                        <MenuFlyoutItem x:Name="White" Text="White" Click="White_Click" />
-                        <MenuFlyoutItem x:Name="Yellow" Text="Yellow" Click="Yellow_Click" />
-                        <MenuFlyoutItem x:Name="Blue" Text="Blue" Click="Blue_Click" />
-                        <MenuFlyoutItem x:Name="Pink" Text="Pink" Click="Pink_Click" />
-                        <MenuFlyoutItem x:Name="Orange" Text="Orange" Click="Orange_Click" />
-                        <MenuFlyoutItem x:Name="Green" Text="Green" Click="Green_Click" />
+                        <MenuFlyoutItem x:Name="Black" x:Uid="TextColorBlack" Text="Black" Click="Black_Click" />
+                        <MenuFlyoutItem x:Name="White" x:Uid="TextColorWhite" Text="White" Click="White_Click" />
+                        <MenuFlyoutItem x:Name="Yellow" x:Uid="TextColorYellow" Text="Yellow" Click="Yellow_Click" />
+                        <MenuFlyoutItem x:Name="Blue" x:Uid="TextColorBlue" Text="Blue" Click="Blue_Click" />
+                        <MenuFlyoutItem x:Name="Pink" x:Uid="TextColorPink" Text="Pink" Click="Pink_Click" />
+                        <MenuFlyoutItem x:Name="Orange" x:Uid="TextColorOrange" Text="Orange" Click="Orange_Click" />
+                        <MenuFlyoutItem x:Name="Green" x:Uid="TextColorGreen" Text="Green" Click="Green_Click" />
                     </MenuFlyout>
                 </AppBarButton.Flyout>
             </AppBarButton>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -2,11 +2,8 @@
     x:Class="Quick_Pad_Free_Edition.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Quick_Pad_Free_Edition"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:UI="using:Microsoft.Advertising.WinRT.UI"
-    xmlns:adduplex="using:AdDuplex"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     mc:Ignorable="d">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -32,15 +32,25 @@
             <Frame x:Name="FrameTop" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Visibility="Visible" VerticalAlignment="Top" Height="40" Grid.RowSpan="1" Margin="0,0,0,0"/>
         </controls:DropShadowPanel>
 
-        <Button x:Name="CloseFocusMode" ToolTipService.ToolTip="Exit focus mode" Click="CloseFocusMode_Click" Visibility="Collapsed" HorizontalAlignment="Right" Content="°°°" VerticalAlignment="Top" Margin="0,50,30,0" Canvas.ZIndex="1500" VerticalContentAlignment="Center" FontSize="10" Width="35" Height="20" Windows10version1809:CornerRadius="2"/>
+        <Button x:Name="CloseFocusMode" Click="CloseFocusMode_Click" Visibility="Collapsed" HorizontalAlignment="Right" Content="°°°" VerticalAlignment="Top" Margin="0,50,30,0" Canvas.ZIndex="1500" VerticalContentAlignment="Center" FontSize="10" Width="35" Height="20" Windows10version1809:CornerRadius="2">
+            <ToolTipService.ToolTip>
+                <TextBlock Text="Exit focus mode" x:Uid="ExitFocusMode"/>
+            </ToolTipService.ToolTip>
+        </Button>
 
         <CommandBar x:Name="CommandBar1" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False"  Margin="0,33,360,0" HorizontalAlignment="Left" Grid.RowSpan="1" VerticalAlignment="Top" Height="40"  Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}">
-            <AppBarButton x:Name="CmdNew" x:Uid="CmdNew" Label="New" Width="Auto" MinWidth="40" Click="CmdNew_Click" ToolTipService.ToolTip="New">
+            <AppBarButton x:Name="CmdNew" x:Uid="CmdNew" Label="New" Width="Auto" MinWidth="40" Click="CmdNew_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="New" x:Uid="CmdNewTooltip"/>
+                </ToolTipService.ToolTip>
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xE7C3;"/>
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarButton x:Name="CmdOpen" x:Uid="CmdOpen" Label="Open"  Width="Auto" MinWidth="40" Click="CmdOpen_Click" ToolTipService.ToolTip="Open (Ctrl+O)">
+            <AppBarButton x:Name="CmdOpen" x:Uid="CmdOpen" Label="Open"  Width="Auto" MinWidth="40" Click="CmdOpen_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Open (Ctrl+O)" x:Uid="CmdOpenTooltip"/>
+                </ToolTipService.ToolTip>
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xF12B;"/>
                 </AppBarButton.Icon>
@@ -50,7 +60,10 @@
                            Key="O" />
                 </AppBarButton.KeyboardAccelerators>
             </AppBarButton>
-            <AppBarButton x:Name="CmdSave" x:Uid="CmdSave" Label="Save" Width="Auto" MinWidth="40" Icon="Save" Click="CmdSave_Click" ToolTipService.ToolTip="Save (Ctrl+S)" LabelPosition="Collapsed">
+            <AppBarButton x:Name="CmdSave" x:Uid="CmdSave" Label="Save" Width="Auto" MinWidth="40" Icon="Save" Click="CmdSave_Click" LabelPosition="Collapsed">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Save (Ctrl+S)" x:Uid="CmdSaveTooltip"/>
+                </ToolTipService.ToolTip>
                 <AppBarButton.KeyboardAccelerators>
                     <KeyboardAccelerator 
                           Modifiers="Control" 
@@ -58,47 +71,117 @@
                 </AppBarButton.KeyboardAccelerators>
             </AppBarButton>
             <AppBarSeparator/>
-            <AppBarButton x:Name="Bold" x:Uid="Bold"  Label="Bold"  Width="Auto" MinWidth="40" Click="Bold_Click" Icon="Bold" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Bold (Ctrl+B)"/>
-            <AppBarButton x:Name="Italic" x:Uid="Italic" Label="Italic" Width="Auto" MinWidth="40" Click="Italic_Click" Icon="Italic" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Italic (Ctrl+I)"/>
-            <AppBarButton x:Name="Underline" x:Uid="Underline" Label="Underline" Width="Auto" MinWidth="40" Click="Underline_Click" Icon="Underline" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Underline (Ctrl+U)"/>
-            <AppBarButton x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" ToolTipService.ToolTip="Strikethrough" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Center" Click="Strikethrough_Click">
+            <AppBarButton x:Name="Bold" x:Uid="Bold"  Label="Bold"  Width="Auto" MinWidth="40" Click="Bold_Click" Icon="Bold" HorizontalAlignment="Stretch">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Bold (Ctrl+B)" x:Uid="BoldTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Italic" x:Uid="Italic" Label="Italic" Width="Auto" MinWidth="40" Click="Italic_Click" Icon="Italic" HorizontalAlignment="Stretch">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Italic (Ctrl+I)" x:Uid="ItalicTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Underline" x:Uid="Underline" Label="Underline" Width="Auto" MinWidth="40" Click="Underline_Click" Icon="Underline" HorizontalAlignment="Stretch">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Underline (Ctrl+U)" x:Uid="UnderlineTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Center" Click="Strikethrough_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Strikethrough" x:Uid="StrikethroughTooltip"/>
+                </ToolTipService.ToolTip>
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="Visible" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Toggle Bullets"/>
+            <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="Visible" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Toggle Bullets" x:Uid="BuTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
             <AppBarSeparator/>
-            <AppBarButton x:Name="Left" x:Uid="Left" Label="Left" Width="Auto" MinWidth="40" Click="Left_Click" Icon="AlignLeft" ToolTipService.ToolTip="Align left (Ctrl+L)"/>
-            <AppBarButton x:Name="Center" x:Uid="Center" Label="Center" Width="Auto" MinWidth="40" Click="Center_Click" Icon="AlignCenter" ToolTipService.ToolTip="Align center (Ctrl+E)"/>
-            <AppBarButton x:Name="Right" x:Uid="Right" Label="Right"  Width="Auto" MinWidth="40" Click="Right_Click" Icon="AlignRight" ToolTipService.ToolTip="Align right (Ctrl+R)"/>
-            <AppBarButton x:Name="Justify" x:Uid="Justify" Label="Justify"  Width="Auto" MinWidth="40" Click="Justify_Click" ToolTipService.ToolTip="Justify text (Ctrl+J)" Background="{x:Null}" >
+            <AppBarButton x:Name="Left" x:Uid="Left" Label="Left" Width="Auto" MinWidth="40" Click="Left_Click" Icon="AlignLeft">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Align left (Ctrl+L)" x:Uid="LeftTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Center" x:Uid="Center" Label="Center" Width="Auto" MinWidth="40" Click="Center_Click" Icon="AlignCenter">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Align center (Ctrl+E)" x:Uid="CenterTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Right" x:Uid="Right" Label="Right"  Width="Auto" MinWidth="40" Click="Right_Click" Icon="AlignRight">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Align right (Ctrl+R)" x:Uid="RightTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Justify" x:Uid="Justify" Label="Justify"  Width="Auto" MinWidth="40" Click="Justify_Click" Background="{x:Null}" >
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Justify text (Ctrl+J)" x:Uid="JustifyTooltip"/>
+                </ToolTipService.ToolTip>
                 <AppBarButton.Icon>
                     <BitmapIcon UriSource="/Assets/justify align.png"/>
                 </AppBarButton.Icon>
             </AppBarButton>
             <AppBarSeparator x:Name="AlignSeparator" />
-            <AppBarButton x:Name="SizeUp" x:Uid="SizeUp" Label="Size Up" Width="Auto" MinWidth="40" Click="SizeUp_Click" Icon="FontIncrease" ToolTipService.ToolTip="Size Up" />
-            <AppBarButton x:Name="SizeDown" x:Uid="SizeDown" Label="Size Down"  Width="Auto" MinWidth="40" Click="SizeDown_Click" Icon="FontDecrease" ToolTipService.ToolTip="Size Down" />
+            <AppBarButton x:Name="SizeUp" x:Uid="SizeUp" Label="Size Up" Width="Auto" MinWidth="40" Click="SizeUp_Click" Icon="FontIncrease">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Size Up" x:Uid="SizeUpTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="SizeDown" x:Uid="SizeDown" Label="Size Down"  Width="Auto" MinWidth="40" Click="SizeDown_Click" Icon="FontDecrease">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Size Down" x:Uid="SizeDownTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
         </CommandBar>
 
         <CommandBar x:Name="CommandBar2" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False"  HorizontalAlignment="Right" Grid.RowSpan="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Margin="0,33,0,0">
             <CommandBar.SecondaryCommands>
                 <AppBarButton x:Name="CmdFocusMode" x:Uid="CmdFocusMode" Click="CmdFocusMode_Click"  Icon="Caption" Label="Focus Mode" Width="Auto"/>
-                <AppBarButton x:Name="CmdShare" x:Uid="CmdShare" Label="Share"  Width="Auto" MinWidth="40" Icon="Share" Click="CmdShare_Click" ToolTipService.ToolTip="Share the file you are working on."/>
+                <AppBarButton x:Name="CmdShare" x:Uid="CmdShare" Label="Share"  Width="Auto" MinWidth="40" Icon="Share" Click="CmdShare_Click" >
+                    <ToolTipService.ToolTip>
+                        <TextBlock Text="Share the file you are working on." x:Uid="CmdShareTooltip"/>
+                    </ToolTipService.ToolTip>
+                </AppBarButton>
                 <AppBarButton x:Name="CmdReview" x:Uid="CmdReview" Icon="SolidStar" Label="Review" Click="CmdReview_Click" Width="Auto"/>
-                <AppBarButton x:Name="CmdSettings" x:Uid="CmdSettings" Icon="Setting" Label="Settings" Width="Auto" Visibility="Visible" Click="CmdSettings_Click" ToolTipService.ToolTip="Settings"/>
+                <AppBarButton x:Name="CmdSettings" x:Uid="CmdSettings" Icon="Setting" Label="Settings" Width="Auto" Visibility="Visible" Click="CmdSettings_Click">
+                    <ToolTipService.ToolTip>
+                        <TextBlock Text="Settings" x:Uid="CmdSettingsTooltip"/>
+                    </ToolTipService.ToolTip>
+                </AppBarButton>
             </CommandBar.SecondaryCommands>
-            <AppBarButton x:Name="CmdUndo" Label="Undo" x:Uid="CmdUndo" Width="Auto" MinWidth="40" Icon="Undo" Visibility="Visible"  Click="CmdUndo_Click" ToolTipService.ToolTip="Undo (Ctrl+Z)"/>
-            <AppBarButton x:Name="CmdRedo" Label="Redo" x:Uid="CmdRedo" Width="Auto" MinWidth="40" Icon="Redo" Visibility="Visible" Click="CmdRedo_Click" ToolTipService.ToolTip="Redo (Ctrl+Y)"/>
+            <AppBarButton x:Name="CmdUndo" Label="Undo" x:Uid="CmdUndo" Width="Auto" MinWidth="40" Icon="Undo" Visibility="Visible"  Click="CmdUndo_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Undo (Ctrl+Z)" x:Uid="CmdUndoTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="CmdRedo" Label="Redo" x:Uid="CmdRedo" Width="Auto" MinWidth="40" Icon="Redo" Visibility="Visible" Click="CmdRedo_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Redo (Ctrl+Y)" x:Uid="CmdRedoTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
             <AppBarSeparator x:Name="ASep1"/>
             <AppBarToggleButton x:Name="CompactOverlay" x:Uid="CompactOverlay" Content="On Top" HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Checked="CompactOverlay_Checked" Unchecked="CompactOverlay_Unchecked">
                 <AppBarToggleButton.KeyboardAccelerators>
                     <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
                 </AppBarToggleButton.KeyboardAccelerators>
             </AppBarToggleButton>
-            <AppBarButton x:Name="Copy" x:Uid="Copy" Label="Copy"  Width="Auto" MinWidth="40" Icon="Copy" Click="Copy_Click" ToolTipService.ToolTip="Copy (Ctrl+C)"/>
-            <AppBarButton x:Name="Paste" x:Uid="Paste" Label="Paste" Width="Auto" MinWidth="40" Icon="Paste" Click="Paste_Click" ToolTipService.ToolTip="Paste (Ctrl+V)"/>
-            <AppBarButton x:Name="Cut" x:Uid="Cut" Label="Cut" Width="Auto" MinWidth="40" Icon="Cut" Click="Cut_Click" ToolTipService.ToolTip="Cut (Ctrl+X)"/>
+            <AppBarButton x:Name="Copy" x:Uid="Copy" Label="Copy"  Width="Auto" MinWidth="40" Icon="Copy" Click="Copy_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Copy (Ctrl+C)" x:Uid="CopyTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Paste" x:Uid="Paste" Label="Paste" Width="Auto" MinWidth="40" Icon="Paste" Click="Paste_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Paste (Ctrl+V)" x:Uid="PasteTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
+            <AppBarButton x:Name="Cut" x:Uid="Cut" Label="Cut" Width="Auto" MinWidth="40" Icon="Cut" Click="Cut_Click">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Cut (Ctrl+X)" x:Uid="CutTooltip"/>
+                </ToolTipService.ToolTip>
+            </AppBarButton>
         </CommandBar>
 
         <RichEditBox  x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18"  Style="{StaticResource RichEditBox}"/>
@@ -244,7 +327,10 @@
                     <ComboBox VerticalAlignment="Center" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" MinHeight="40" x:Name="Fonts" PlaceholderText="Segoe UI" SelectionChanged="Fonts_SelectionChanged" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1" PlaceholderForeground="Black"/>
                 </Canvas>
             </CommandBar.Content>
-            <AppBarButton x:Name="TextColor" x:Uid="TextColor" Width="40" Icon="FontColor" ToolTipService.ToolTip="Font Color">
+            <AppBarButton x:Name="TextColor" x:Uid="TextColor" Width="40" Icon="FontColor">
+                <ToolTipService.ToolTip>
+                    <TextBlock Text="Font Color" x:Uid="TextColorTooltip"/>
+                </ToolTipService.ToolTip>
                 <AppBarButton.Flyout>
                     <MenuFlyout>
                         <MenuFlyoutItem x:Name="Black" x:Uid="TextColorBlack" Text="Black" Click="Black_Click" />

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -35,12 +35,12 @@
         <Button x:Name="CloseFocusMode" ToolTipService.ToolTip="Exit focus mode" Click="CloseFocusMode_Click" Visibility="Collapsed" HorizontalAlignment="Right" Content="°°°" VerticalAlignment="Top" Margin="0,50,30,0" Canvas.ZIndex="1500" VerticalContentAlignment="Center" FontSize="10" Width="35" Height="20" Windows10version1809:CornerRadius="2"/>
 
         <CommandBar x:Name="CommandBar1" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False"  Margin="0,33,360,0" HorizontalAlignment="Left" Grid.RowSpan="1" VerticalAlignment="Top" Height="40"  Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}">
-            <AppBarButton x:Name="CmdNew" Label="New" Width="Auto" MinWidth="40" Click="CmdNew_Click" ToolTipService.ToolTip="New">
+            <AppBarButton x:Name="CmdNew" x:Uid="CmdNew" Label="New" Width="Auto" MinWidth="40" Click="CmdNew_Click" ToolTipService.ToolTip="New">
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xE7C3;"/>
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarButton x:Name="CmdOpen" Label="Open"  Width="Auto" MinWidth="40" Click="CmdOpen_Click" ToolTipService.ToolTip="Open (Ctrl+O)">
+            <AppBarButton x:Name="CmdOpen" x:Uid="CmdOpen" Label="Open"  Width="Auto" MinWidth="40" Click="CmdOpen_Click" ToolTipService.ToolTip="Open (Ctrl+O)">
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xF12B;"/>
                 </AppBarButton.Icon>
@@ -50,7 +50,7 @@
                            Key="O" />
                 </AppBarButton.KeyboardAccelerators>
             </AppBarButton>
-            <AppBarButton x:Name="CmdSave" Label="Save" Width="Auto" MinWidth="40" Icon="Save" Click="CmdSave_Click" ToolTipService.ToolTip="Save (Ctrl+S)" LabelPosition="Collapsed">
+            <AppBarButton x:Name="CmdSave" x:Uid="CmdSave" Label="Save" Width="Auto" MinWidth="40" Icon="Save" Click="CmdSave_Click" ToolTipService.ToolTip="Save (Ctrl+S)" LabelPosition="Collapsed">
                 <AppBarButton.KeyboardAccelerators>
                     <KeyboardAccelerator 
                           Modifiers="Control" 
@@ -58,27 +58,27 @@
                 </AppBarButton.KeyboardAccelerators>
             </AppBarButton>
             <AppBarSeparator/>
-            <AppBarButton x:Name="Bold" Label="Bold"  Width="Auto" MinWidth="40" Click="Bold_Click" Icon="Bold" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Bold (Ctrl+B)"/>
-            <AppBarButton x:Name="Italic" Label="Italic" Width="Auto" MinWidth="40" Click="Italic_Click" Icon="Italic" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Italic (Ctrl+I)"/>
-            <AppBarButton x:Name="Underline" Label="Underline" Width="Auto" MinWidth="40" Click="Underline_Click" Icon="Underline" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Underline (Ctrl+U)"/>
-            <AppBarButton x:Name="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" ToolTipService.ToolTip="Strikethrough" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Center" Click="Strikethrough_Click">
+            <AppBarButton x:Name="Bold" x:Uid="Bold"  Label="Bold"  Width="Auto" MinWidth="40" Click="Bold_Click" Icon="Bold" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Bold (Ctrl+B)"/>
+            <AppBarButton x:Name="Italic" x:Uid="Italic" Label="Italic" Width="Auto" MinWidth="40" Click="Italic_Click" Icon="Italic" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Italic (Ctrl+I)"/>
+            <AppBarButton x:Name="Underline" x:Uid="Underline" Label="Underline" Width="Auto" MinWidth="40" Click="Underline_Click" Icon="Underline" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Underline (Ctrl+U)"/>
+            <AppBarButton x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" ToolTipService.ToolTip="Strikethrough" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Center" Click="Strikethrough_Click">
                 <AppBarButton.Icon>
                     <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarButton x:Name="BulletList" Label="Bullets"  Width="Auto" MinWidth="40" Visibility="Visible" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Toggle Bullets"/>
+            <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="Visible" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch" ToolTipService.ToolTip="Toggle Bullets"/>
             <AppBarSeparator/>
-            <AppBarButton x:Name="Left" Label="Left" Width="Auto" MinWidth="40" Click="Left_Click" Icon="AlignLeft" ToolTipService.ToolTip="Align left (Ctrl+L)"/>
-            <AppBarButton x:Name="Center" Label="Center" Width="Auto" MinWidth="40" Click="Center_Click" Icon="AlignCenter" ToolTipService.ToolTip="Align center (Ctrl+E)"/>
-            <AppBarButton x:Name="Right" Label="Right"  Width="Auto" MinWidth="40" Click="Right_Click" Icon="AlignRight" ToolTipService.ToolTip="Align right (Ctrl+R)"/>
-            <AppBarButton x:Name="Justify" Label="Justify"  Width="Auto" MinWidth="40" Click="Justify_Click" ToolTipService.ToolTip="Justify text (Ctrl+J)" Background="{x:Null}" >
+            <AppBarButton x:Name="Left" x:Uid="Left" Label="Left" Width="Auto" MinWidth="40" Click="Left_Click" Icon="AlignLeft" ToolTipService.ToolTip="Align left (Ctrl+L)"/>
+            <AppBarButton x:Name="Center" x:Uid="Center" Label="Center" Width="Auto" MinWidth="40" Click="Center_Click" Icon="AlignCenter" ToolTipService.ToolTip="Align center (Ctrl+E)"/>
+            <AppBarButton x:Name="Right" x:Uid="Right" Label="Right"  Width="Auto" MinWidth="40" Click="Right_Click" Icon="AlignRight" ToolTipService.ToolTip="Align right (Ctrl+R)"/>
+            <AppBarButton x:Name="Justify" x:Uid="Justify" Label="Justify"  Width="Auto" MinWidth="40" Click="Justify_Click" ToolTipService.ToolTip="Justify text (Ctrl+J)" Background="{x:Null}" >
                 <AppBarButton.Icon>
                     <BitmapIcon UriSource="/Assets/justify align.png"/>
                 </AppBarButton.Icon>
             </AppBarButton>
             <AppBarSeparator x:Name="AlignSeparator" />
-            <AppBarButton x:Name="SizeUp" Label="Size Up" Width="Auto" MinWidth="40" Click="SizeUp_Click" Icon="FontIncrease" ToolTipService.ToolTip="Size Up" />
-            <AppBarButton x:Name="SizeDown" Label="Size Down"  Width="Auto" MinWidth="40" Click="SizeDown_Click" Icon="FontDecrease" ToolTipService.ToolTip="Size Down" />
+            <AppBarButton x:Name="SizeUp" x:Uid="SizeUp" Label="Size Up" Width="Auto" MinWidth="40" Click="SizeUp_Click" Icon="FontIncrease" ToolTipService.ToolTip="Size Up" />
+            <AppBarButton x:Name="SizeDown" x:Uid="SizeDown" Label="Size Down"  Width="Auto" MinWidth="40" Click="SizeDown_Click" Icon="FontDecrease" ToolTipService.ToolTip="Size Down" />
         </CommandBar>
 
         <CommandBar x:Name="CommandBar2" DefaultLabelPosition="Collapsed" Canvas.ZIndex="75" IsOpen="False"  HorizontalAlignment="Right" Grid.RowSpan="1" VerticalAlignment="Top" Height="40" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Margin="0,33,0,0">
@@ -88,17 +88,17 @@
                 <AppBarButton x:Name="CmdReview" Icon="SolidStar" Label="Review" Click="CmdReview_Click" Width="Auto"/>
                 <AppBarButton x:Name="CmdSettings" Icon="Setting" Label="Settings" Width="Auto" Visibility="Visible" Click="CmdSettings_Click" ToolTipService.ToolTip="Settings"/>
             </CommandBar.SecondaryCommands>
-            <AppBarButton x:Name="CmdUndo" Label="Undo"  Width="Auto" MinWidth="40" Icon="Undo" Visibility="Visible"  Click="CmdUndo_Click" ToolTipService.ToolTip="Undo (Ctrl+Z)"/>
-            <AppBarButton x:Name="CmdRedo" Label="Redo"  Width="Auto" MinWidth="40" Icon="Redo" Visibility="Visible" Click="CmdRedo_Click" ToolTipService.ToolTip="Redo (Ctrl+Y)"/>
+            <AppBarButton x:Name="CmdUndo" Label="Undo" x:Uid="CmdUndo" Width="Auto" MinWidth="40" Icon="Undo" Visibility="Visible"  Click="CmdUndo_Click" ToolTipService.ToolTip="Undo (Ctrl+Z)"/>
+            <AppBarButton x:Name="CmdRedo" Label="Redo" x:Uid="CmdRedo" Width="Auto" MinWidth="40" Icon="Redo" Visibility="Visible" Click="CmdRedo_Click" ToolTipService.ToolTip="Redo (Ctrl+Y)"/>
             <AppBarSeparator x:Name="ASep1"/>
-            <AppBarToggleButton x:Name="CompactOverlay" Content="On Top" HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Checked="CompactOverlay_Checked" Unchecked="CompactOverlay_Unchecked">
+            <AppBarToggleButton x:Name="CompactOverlay" x:Uid="CompactOverlay" Content="On Top" HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Checked="CompactOverlay_Checked" Unchecked="CompactOverlay_Unchecked">
                 <AppBarToggleButton.KeyboardAccelerators>
                     <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
                 </AppBarToggleButton.KeyboardAccelerators>
             </AppBarToggleButton>
-            <AppBarButton x:Name="Copy" Label="Copy"  Width="Auto" MinWidth="40" Icon="Copy" Click="Copy_Click" ToolTipService.ToolTip="Copy (Ctrl+C)"/>
-            <AppBarButton x:Name="Paste" Label="Paste" Width="Auto" MinWidth="40" Icon="Paste" Click="Paste_Click" ToolTipService.ToolTip="Paste (Ctrl+V)"/>
-            <AppBarButton x:Name="Cut" Label="Cut" Width="Auto" MinWidth="40" Icon="Cut" Click="Cut_Click" ToolTipService.ToolTip="Cut (Ctrl+X)"/>
+            <AppBarButton x:Name="Copy" x:Uid="Copy" Label="Copy"  Width="Auto" MinWidth="40" Icon="Copy" Click="Copy_Click" ToolTipService.ToolTip="Copy (Ctrl+C)"/>
+            <AppBarButton x:Name="Paste" x:Uid="Paste" Label="Paste" Width="Auto" MinWidth="40" Icon="Paste" Click="Paste_Click" ToolTipService.ToolTip="Paste (Ctrl+V)"/>
+            <AppBarButton x:Name="Cut" x:Uid="Cut" Label="Cut" Width="Auto" MinWidth="40" Icon="Cut" Click="Cut_Click" ToolTipService.ToolTip="Cut (Ctrl+X)"/>
         </CommandBar>
 
         <RichEditBox  x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18"  Style="{StaticResource RichEditBox}"/>
@@ -108,10 +108,10 @@
             <StackPanel HorizontalAlignment="Stretch" Height="120" VerticalAlignment="Stretch">
                 <Grid>
                     <TextBlock Text="Quick Pad" FontSize="24"/>
-                    <TextBlock Text="Would you like to save your changes?" Margin="0,37,0,0"/>
-                    <Button Content="Yes" x:Name="SaveDialogYes" Click="SaveDialogYes_Click" Windows10version1809:CornerRadius="2" Margin="-167,85,0,0" Width="80" HorizontalAlignment="Center"/>
-                    <Button Content="No" x:Name="SaveDialogNo" Click="SaveDialogNo_Click" Windows10version1809:CornerRadius="2" Margin="0,85,0,0" Width="80" HorizontalAlignment="Center"/>
-                    <Button Content="Cancel" x:Name="SaveDialogCancel" Click="SaveDialogCancel_Click"  Windows10version1809:CornerRadius="2" Margin="168,85,0,0" Width="80" HorizontalAlignment="Center"/>
+                    <TextBlock x:Uid="SaveDialog" Text="Would you like to save your changes?" Margin="0,37,0,0"/>
+                    <Button Content="Yes" x:Name="SaveDialogYes" x:Uid="SaveDialogYes" Click="SaveDialogYes_Click" Windows10version1809:CornerRadius="2" Margin="-167,85,0,0" Width="80" HorizontalAlignment="Center"/>
+                    <Button Content="No" x:Name="SaveDialogNo" x:Uid="SaveDialogNo" Click="SaveDialogNo_Click" Windows10version1809:CornerRadius="2" Margin="0,85,0,0" Width="80" HorizontalAlignment="Center"/>
+                    <Button Content="Cancel" x:Name="SaveDialogCancel" x:Uid="SaveDialogCancel" Click="SaveDialogCancel_Click"  Windows10version1809:CornerRadius="2" Margin="168,85,0,0" Width="80" HorizontalAlignment="Center"/>
                 </Grid>
             </StackPanel>
         </ContentDialog>
@@ -123,48 +123,48 @@
                     <CommandBar x:Name="CmdSettingsBack" Canvas.ZIndex="100" HorizontalAlignment="Right" Grid.RowSpan="1" VerticalAlignment="Top" Height="40" Background="{x:Null}" Margin="0,0,0,0">
                         <AppBarButton x:Name="CmdBack" Windows10version1809:CornerRadius="2" Width="40" Icon="Clear" Click="CmdBack_Click"/>
                     </CommandBar>
-                    <Pivot x:Name="SettingsPivot" Title="Settings" Width="Auto" Margin="0,0,0,0">
+                    <Pivot x:Name="SettingsPivot" x:Uid="SettingsPivot" Title="Settings" Width="Auto" Margin="0,0,0,0">
                         <Pivot.HeaderTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding}" FontSize="20" FontFamily="Segoe UI"/>
                             </DataTemplate>
                         </Pivot.HeaderTemplate>
-                        <PivotItem Header="General" x:Name="SettingsTab1">
-                            <ScrollViewer x:Name="SettingsTab1SV"  Height="200">
+                        <PivotItem Header="General" x:Name="SettingsTab1" x:Uid="SettingsTab1">
+                            <ScrollViewer x:Name="SettingsTab1SV" Height="200">
                                 <Grid Height="340">
-                                    <TextBlock Text="Launch Mode" Margin="0,10,23,87" TextWrapping="Wrap"/>
-                                    <ComboBox Margin="0,35,0,0" PlaceholderText="Default" SelectionChanged="LaunchOptions_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="LaunchOptions" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="125" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
+                                    <TextBlock Text="Launch Mode" x:Uid="GeneralLaunchMode" Margin="0,10,23,87" TextWrapping="Wrap"/>
+                                    <ComboBox Margin="0,35,0,0" x:Uid="GeneralLaunchMode" PlaceholderText="Default" SelectionChanged="LaunchOptions_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="LaunchOptions" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="125" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                         <x:String>Default</x:String>
                                         <x:String>On Top</x:String>
                                         <x:String>Focus Mode</x:String>
                                     </ComboBox>
-                                    <TextBlock Text="Default File Type" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Segoe UI"/>
+                                    <TextBlock x:Uid="GeneralDefaultType" Text="Default File Type" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Segoe UI"/>
                                     <ComboBox Margin="0,105,0,0" PlaceholderText=".rtf" SelectionChanged="DefaultFileType_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                         <x:String>.rtf</x:String>
                                         <x:String>.txt</x:String>
                                     </ComboBox>
-                                    <TextBlock Text="Auto Save" Margin="0,150,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
-                                    <ToggleSwitch x:Name="AutoSaveSwitch" OnContent="On" OffContent="Off" Toggled="AutoSaveSwitch_Toggled" HorizontalAlignment="Left" Margin="0,170,0,0" VerticalAlignment="Top" />
-                                    <TextBlock Text="Word Wrap" Margin="0,215,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
-                                    <ToggleSwitch x:Name="WordWrap" OnContent="On" OffContent="Off" Toggled="WordWrap_Toggled" HorizontalAlignment="Left" Margin="0,235,0,0" VerticalAlignment="Top" />
-                                    <TextBlock Text="Spell Check" Margin="0,280,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
-                                    <ToggleSwitch x:Name="SpellCheck" OnContent="On" OffContent="Off" Toggled="SpellCheck_Toggled" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" />
+                                    <TextBlock x:Uid="AutoSaveSwitch" Text="Auto Save" Margin="0,150,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
+                                    <ToggleSwitch x:Name="AutoSaveSwitch" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="AutoSaveSwitch_Toggled" HorizontalAlignment="Left" Margin="0,170,0,0" VerticalAlignment="Top" />
+                                    <TextBlock x:Uid="WordWrap" Text="Word Wrap" Margin="0,215,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
+                                    <ToggleSwitch x:Name="WordWrap" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="WordWrap_Toggled" HorizontalAlignment="Left" Margin="0,235,0,0" VerticalAlignment="Top" />
+                                    <TextBlock x:Uid="SpellCheck" Text="Spell Check" Margin="0,280,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
+                                    <ToggleSwitch x:Name="SpellCheck" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="SpellCheck_Toggled" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" />
                                 </Grid>
                             </ScrollViewer>
                         </PivotItem>
-                        <PivotItem Header="Theme" x:Name="SettingsTab2">
+                        <PivotItem Header="Theme" x:Name="SettingsTab2" x:Uid="SettingsTab2">
                             <Grid Height="200">
-                                <TextBlock Text="App Theme" Margin="0,5,0,0" TextWrapping="Wrap" FontSize="18"/>
-                                <RadioButton x:Name="Light" Content="Light" HorizontalAlignment="Left" Height="38" Margin="0,40,0,0" VerticalAlignment="Top" Width="242" Click="Light_Click" Grid.RowSpan="2"/>
-                                <RadioButton x:Name="Dark" Content="Dark" HorizontalAlignment="Left" Height="38" Margin="0,80,0,0" VerticalAlignment="Top" Width="242" Click="Dark_Click"/>
-                                <RadioButton x:Name="SystemDefault" IsChecked="True" Content="System Default" HorizontalAlignment="Left" Height="38" Margin="0,120,0,0" VerticalAlignment="Top"  Width="242" Click="SystemDefault_Click" Grid.RowSpan="1"/>
+                                <TextBlock x:Uid="AppTheme" Text="App Theme" Margin="0,5,0,0" TextWrapping="Wrap" FontSize="18"/>
+                                <RadioButton x:Name="Light" x:Uid="Light" Content="Light" HorizontalAlignment="Left" Height="38" Margin="0,40,0,0" VerticalAlignment="Top" Width="242" Click="Light_Click" Grid.RowSpan="2"/>
+                                <RadioButton x:Name="Dark" x:Uid="Dark" Content="Dark" HorizontalAlignment="Left" Height="38" Margin="0,80,0,0" VerticalAlignment="Top" Width="242" Click="Dark_Click"/>
+                                <RadioButton x:Name="SystemDefault" x:Uid="SystemDefault" IsChecked="True" Content="System Default" HorizontalAlignment="Left" Height="38" Margin="0,120,0,0" VerticalAlignment="Top"  Width="242" Click="SystemDefault_Click" Grid.RowSpan="1"/>
                             </Grid>
                         </PivotItem>
-                        <PivotItem Header="Font" x:Name="SettingsTab3">
+                        <PivotItem Header="Font" x:Name="SettingsTab3" x:Uid="SettingsTab3">
                             <Grid Height="200">
-                                <TextBlock Text="Default Font" Margin="0,5,0,0" TextWrapping="Wrap"/>
+                                <TextBlock x:Uid="DefaultFont" Text="Default Font" Margin="0,5,0,0" TextWrapping="Wrap"/>
                                 <ComboBox Margin="0,30,0,0" Windows10version1809:CornerRadius="2" SelectionChanged="DefaultFont_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" x:Name="DefaultFont" PlaceholderText="Segoe UI" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1"/>
-                                <TextBlock Text="Default Font Size" Margin="0,70,0,0" TextWrapping="Wrap"/>
+                                <TextBlock x:Uid="DefaultFontSize" Text="Default Font Size" Margin="0,70,0,0" TextWrapping="Wrap"/>
                                 <ComboBox Margin="0,95,0,0" Windows10version1809:CornerRadius="2" x:Name="DefaultFontSize" SelectionChanged="DefaultFontSize_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" Width="69" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                     <x:String>4</x:String>
                                     <x:String>6</x:String>
@@ -183,7 +183,7 @@
                                     <x:String>48</x:String>
                                     <x:String>72</x:String>
                                 </ComboBox>
-                                <TextBlock Text="Default Font Color" Margin="0,135,0,0" TextWrapping="Wrap"/>
+                                <TextBlock x:Uid="DefaultFontColor" Text="Default Font Color" Margin="0,135,0,0" TextWrapping="Wrap"/>
                                 <ComboBox Margin="0,160,0,0" x:Name="DefaultFontColor" SelectionChanged="DefaultFontColor_SelectionChanged" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Black" Width="139" BorderThickness="1,1,1,1">
                                     <x:String>Black</x:String>
                                     <x:String>White</x:String>
@@ -195,27 +195,27 @@
                                 </ComboBox>
                             </Grid>
                         </PivotItem>
-                        <PivotItem Header="Toolbar" x:Name="SettingsTab4">
+                        <PivotItem Header="Toolbar" x:Name="SettingsTab4" x:Uid="SettingsTab4">
                             <ScrollViewer x:Name="SettingsTab2SV"  Height="200">
                                 <Grid Height="275">
-                                    <ToggleSwitch x:Name="ShowStrikethrough" OnContent="Show strikethrough option" OffContent="Hide strikethrough option" Toggled="ShowStrikethrough_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,0"/>
-                                    <ToggleSwitch x:Name="ShowBullets" OnContent="Show bullet list"  OffContent="Hide bullet list" Toggled="ShowBullets_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0, 50,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignLeft" OnContent="Show align left"  OffContent="Hide align left" Toggled="ShowAlignLeft_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,95,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignCenter" OnContent="Show align center"  OffContent="Hide align center" Toggled="ShowAlignCenter_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,140,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignRight" OnContent="Show align right"  OffContent="Hide align right" Toggled="ShowAlignRight_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,185,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignJustify" OnContent="Show align justify"  OffContent="Hide align justify" Toggled="ShowAlignJustify_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,230,0,0"/>
+                                    <ToggleSwitch x:Name="ShowStrikethrough" x:Uid="ShowStrikethrough" OnContent="Show strikethrough option" OffContent="Hide strikethrough option" Toggled="ShowStrikethrough_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                                    <ToggleSwitch x:Name="ShowBullets" x:Uid="ShowBullets" OnContent="Show bullet list"  OffContent="Hide bullet list" Toggled="ShowBullets_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0, 50,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignLeft" x:Uid="ShowAlignLeft" OnContent="Show align left"  OffContent="Hide align left" Toggled="ShowAlignLeft_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,95,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignCenter" x:Uid="ShowAlignCenter" OnContent="Show align center"  OffContent="Hide align center" Toggled="ShowAlignCenter_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,140,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignRight" x:Uid="ShowAlignRight" OnContent="Show align right"  OffContent="Hide align right" Toggled="ShowAlignRight_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,185,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignJustify" x:Uid="ShowAlignJustify" OnContent="Show align justify"  OffContent="Hide align justify" Toggled="ShowAlignJustify_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,230,0,0"/>
                                 </Grid>
                             </ScrollViewer>
                         </PivotItem>
-                        <PivotItem Header="About" x:Name="SettingsTab5">
+                        <PivotItem Header="About" x:Name="SettingsTab5" x:Uid="SettingsTab5">
                             <Grid Height="200">
                                     <TextBlock Text="Version number" x:Name="VersionNumber" Margin="0,15,0,0" HorizontalAlignment="Center" FontSize="14" FontFamily="Segoe UI"/>
-                                    <TextBlock Text="Developed by Yair Aichenbaum" Margin="0,40,0,0" FontFamily="Segoe UI" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="Icon desgin by James Arney" Margin="0,65,0,0" HorizontalAlignment="Center" FontFamily="Segoe UI"/>
-                                <HyperlinkButton Content="Send Feedback" Margin="0,90,0,0" FontSize="14" HorizontalAlignment="Center" FontFamily="Segoe UI" VerticalAlignment="Top" NavigateUri="https://feedback.userreport.com/0a1a1038-4b33-4cc9-ad5e-ed71af43bb39/#ideas/popular"/>
-                                    <HyperlinkButton Content="Rate and review" Click="CmdReview_Click" Margin="0,115,0,0" FontSize="14" HorizontalAlignment="Center" FontFamily="Segoe UI" VerticalAlignment="Top"/>
-                                    <HyperlinkButton Content="Contribute to the developer" Margin="0,140,0,0" FontSize="14" HorizontalAlignment="Center" FontFamily="Segoe UI" VerticalAlignment="Top" NavigateUri="http://paypal.me/yaichenbaum"/>
-                                </Grid>
+                                    <TextBlock Text="Developed by Yair Aichenbaum" x:Uid="DevelopedBy" Margin="0,40,0,0" FontFamily="Segoe UI" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="Icon design by James Arney" x:Uid="IconDesignBy" Margin="0,65,0,0" HorizontalAlignment="Center" FontFamily="Segoe UI"/>
+                                    <HyperlinkButton Content="Send Feedback" x:Uid="SendFeedback" Margin="0,90,0,0" FontSize="14" HorizontalAlignment="Center" FontFamily="Segoe UI" VerticalAlignment="Top" NavigateUri="https://feedback.userreport.com/0a1a1038-4b33-4cc9-ad5e-ed71af43bb39/#ideas/popular"/>
+                                    <HyperlinkButton Content="Rate and review" x:Uid="RateAndReview" Click="CmdReview_Click" Margin="0,115,0,0" FontSize="14" HorizontalAlignment="Center" FontFamily="Segoe UI" VerticalAlignment="Top"/>
+                                    <HyperlinkButton Content="Contribute to the developer" x:Uid="Contribute" Margin="0,140,0,0" FontSize="14" HorizontalAlignment="Center" FontFamily="Segoe UI" VerticalAlignment="Top" NavigateUri="http://paypal.me/yaichenbaum"/>
+                            </Grid>
                         </PivotItem>
                     </Pivot>
                     <Grid>
@@ -244,7 +244,7 @@
                     <ComboBox VerticalAlignment="Center" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" MinHeight="40" x:Name="Fonts" PlaceholderText="Segoe UI" SelectionChanged="Fonts_SelectionChanged" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1" PlaceholderForeground="Black"/>
                 </Canvas>
             </CommandBar.Content>
-            <AppBarButton x:Name="TextColor" Width="40" Icon="FontColor" ToolTipService.ToolTip="Font Color">
+            <AppBarButton x:Name="TextColor" x:Uid="TextColor" Width="40" Icon="FontColor" ToolTipService.ToolTip="Font Color">
                 <AppBarButton.Flyout>
                     <MenuFlyout>
                         <MenuFlyoutItem x:Name="Black" Text="Black" Click="Black_Click" />

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.ApplicationModel.Resources;
 using Windows.Services.Store;
 using Windows.Storage;
 using Windows.System;
@@ -26,7 +27,9 @@ namespace Quick_Pad_Free_Edition
 {
     public sealed partial class MainPage : Page
     {
-        private string UpdateFile = "New Document"; //Default file name is "New Document"
+        public ResourceLoader textResource { get; } = ResourceLoader.GetForCurrentView(); //Use to get a text resource from Strings/en-US
+        private string DefaultFilename => textResource.GetString("NewDocument");
+        private string UpdateFile; //Default file name is "New Document"
         private String FullFilePath; //this is the opened files full path
         private string key; //future access list
         private bool _isPageLoaded = false;
@@ -45,6 +48,7 @@ namespace Quick_Pad_Free_Edition
             titleBar.ButtonBackgroundColor = Colors.Transparent;
             titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
+            UpdateFile = DefaultFilename;
             TQuick.Text = UpdateFile; //Displays file name on title bar
 
             LoadSettings();
@@ -52,7 +56,7 @@ namespace Quick_Pad_Free_Edition
             CheckToolbarOptions(); //check which buttons to show in toolbar
             CheckTheme(); //check the theme
 
-            VersionNumber.Text = string.Format("Version: {0}.{1}.{2}.{3}", Package.Current.Id.Version.Major, Package.Current.Id.Version.Minor, Package.Current.Id.Version.Build, Package.Current.Id.Version.Revision);
+            VersionNumber.Text = string.Format(textResource.GetString("VersionFormat"), Package.Current.Id.Version.Major, Package.Current.Id.Version.Minor, Package.Current.Id.Version.Build, Package.Current.Id.Version.Revision);
 
             //check if focus is on app or off the app
             Window.Current.CoreWindow.Activated += (sender, args) =>
@@ -432,10 +436,10 @@ namespace Quick_Pad_Free_Edition
         {
             ContentDialog deleteFileDialog = new ContentDialog //brings up a content dialog
             {
-                Title = "Do you enjoy using Quick Pad?",
-                Content = "Please consider leaving a review for Quick Pad in the store.",
-                PrimaryButtonText = "Yes",
-                CloseButtonText = "No"
+                Title = textResource.GetString("NewUserFeedbackTitle"),//"Do you enjoy using Quick Pad?",
+                Content = textResource.GetString("NewUserFeedbackContent"),//"Please consider leaving a review for Quick Pad in the store.",
+                PrimaryButtonText = textResource.GetString("NewUserFeedbackYes"),//"Yes",
+                CloseButtonText = textResource.GetString("NewUserFeedbackNo"),//"No"
             };
 
             ContentDialogResult result = await deleteFileDialog.ShowAsync(); //get the results if the user clicked to review or not
@@ -535,7 +539,7 @@ namespace Quick_Pad_Free_Edition
                 {
                     Text1.Document.SetText(Windows.UI.Text.TextSetOptions.FormatRtf, string.Empty);
 
-                    UpdateFile = "New Document"; //reset the value of the friendly file name
+                    UpdateFile = DefaultFilename; //reset the value of the friendly file name
                     TQuick.Text = UpdateFile; //update the title bar to reflect it is a new document
                     FullFilePath = ""; //clear the path of the open file since there is none
                     SetTaskBarTitle(); //update the title in the taskbar
@@ -548,7 +552,7 @@ namespace Quick_Pad_Free_Edition
             {
                 Text1.Document.SetText(Windows.UI.Text.TextSetOptions.FormatRtf, string.Empty);
 
-                UpdateFile = "New Document"; //reset the value of the friendly file name
+                UpdateFile = DefaultFilename; //reset the value of the friendly file name
                 TQuick.Text = UpdateFile; //update the title bar to reflect it is a new document
                 FullFilePath = ""; //clear the path of the open file since there is none
                 SetTaskBarTitle(); //update the title in the taskbar
@@ -925,7 +929,8 @@ namespace Quick_Pad_Free_Edition
             }
             else
             {
-                args.Request.FailWithDisplayText("Nothing to share, type something in order to share it.");
+                //"Nothing to share, type something in order to share it."
+                args.Request.FailWithDisplayText(textResource.GetString("NothingToShare"));
             }
         }
 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.Services.Store.Engagement;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
@@ -385,16 +386,16 @@ namespace Quick_Pad_Free_Edition
                     String DefaultFontColors = localSettings.Values["DefaultFontColor"] as string;
                     if (DefaultFontColors != "")
                     {
-                        DefaultFontColor.SelectedItem = DefaultFontColors;
-                        Text1.Document.Selection.CharacterFormat.ForegroundColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), DefaultFontColor.SelectedValue);
+                        ComboBoxItem comboboxItem = (ComboBoxItem)DefaultFontColor.Items.ToList().First(i => ((ComboBoxItem)i).Tag.ToString() == DefaultFontColors);
+                        DefaultFontColor.SelectedItem = comboboxItem;
+                        Text1.Document.Selection.CharacterFormat.ForegroundColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), comboboxItem.Tag);
                     }
                 }
                 catch (Exception) //no setting was found
                 {
-                    if (this.RequestedTheme == ElementTheme.Dark || App.Current.RequestedTheme == ApplicationTheme.Dark)
-                    {
-                        DefaultFontColor.PlaceholderText = "White";
-                    }
+                    DefaultFontColor.Text = RequestedTheme == ElementTheme.Dark ?
+                        textResource.GetString("PlaceholderWhite") :
+                        textResource.GetString("PlaceholderBlack");
                 }
 
                 //check what default font size is and set it

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -143,16 +143,16 @@ namespace Quick_Pad_Free_Edition
             if (launchValue == "On Top")
             {
                 CompactOverlay.IsChecked = true; //launch compact overlay mode
-                LaunchOptions.SelectedValue = "On Top";
+                LaunchOptions.SelectedValue = LaunchModeOnTop;
             }
 
             if (launchValue == "Focus Mode")
             {
                 SwitchToFocusMode();
-                LaunchOptions.SelectedValue = "Focus Mode";
+                LaunchOptions.SelectedValue = LaunchModeFocus;
             }
 
-            if (launchValue == "Default") LaunchOptions.SelectedValue = "Default";
+            if (launchValue == "Default") LaunchOptions.SelectedValue = LaunchModeDefault;
         }
 
         private void LoadSettings()
@@ -1378,8 +1378,8 @@ namespace Quick_Pad_Free_Edition
 
         private void DefaultFontColor_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            localSettings.Values["DefaultFontColor"] = DefaultFontColor.SelectedValue;
-            Text1.Document.Selection.CharacterFormat.ForegroundColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), DefaultFontColor.SelectedValue);
+            localSettings.Values["DefaultFontColor"] = (DefaultFontColor.SelectedValue as ComboBoxItem).Tag;
+            Text1.Document.Selection.CharacterFormat.ForegroundColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), (DefaultFontColor.SelectedValue as ComboBoxItem).Tag);
         }
 
         private void SwitchToFocusMode()
@@ -1409,7 +1409,7 @@ namespace Quick_Pad_Free_Edition
 
         private void LaunchOptions_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            localSettings.Values["LaunchMode"] = LaunchOptions.SelectedValue;
+            localSettings.Values["LaunchMode"] = (LaunchOptions.SelectedValue as ComboBoxItem).Tag;
         }
 
         private void DefaultFileType_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -310,6 +310,82 @@
           <source>Version: {0}.{1}.{2}.{3}</source>
           <target state="translated">เวอร์ชั่น: {0}.{1}.{2}.{3}</target>
         </trans-unit>
+        <trans-unit id="FontColorBlack.Content" translate="yes" xml:space="preserve">
+          <source>Black</source>
+          <target state="translated">ดำ</target>
+        </trans-unit>
+        <trans-unit id="FontColorLightGreen.Content" translate="yes" xml:space="preserve">
+          <source>Green</source>
+          <target state="translated">เขียว</target>
+        </trans-unit>
+        <trans-unit id="FontColorLightPink.Content" translate="yes" xml:space="preserve">
+          <source>Pink</source>
+          <target state="translated">ชมพู</target>
+        </trans-unit>
+        <trans-unit id="FontColorLightSalmon.Content" translate="yes" xml:space="preserve">
+          <source>Orange</source>
+          <target state="translated">ส้ม</target>
+        </trans-unit>
+        <trans-unit id="FontColorLightYellow.Content" translate="yes" xml:space="preserve">
+          <source>Yellow</source>
+          <target state="translated">เหลือง</target>
+        </trans-unit>
+        <trans-unit id="FontColorSkyBlue.Content" translate="yes" xml:space="preserve">
+          <source>Blue</source>
+          <target state="translated">ฟ้า</target>
+        </trans-unit>
+        <trans-unit id="FontColorWhite.Content" translate="yes" xml:space="preserve">
+          <source>White</source>
+          <target state="translated">ขาว</target>
+        </trans-unit>
+        <trans-unit id="LaunchModeDefault.Content" translate="yes" xml:space="preserve">
+          <source>Default</source>
+          <target state="translated">ปกติ</target>
+        </trans-unit>
+        <trans-unit id="LaunchModeFocus.Content" translate="yes" xml:space="preserve">
+          <source>Focus</source>
+          <target state="translated">เน้นพิมพ์</target>
+        </trans-unit>
+        <trans-unit id="LaunchModeOnTop.Content" translate="yes" xml:space="preserve">
+          <source>On Top</source>
+          <target state="translated">ทับแอปอื่น</target>
+        </trans-unit>
+        <trans-unit id="TextColorBlack.Text" translate="yes" xml:space="preserve">
+          <source>Black</source>
+          <target state="translated">ดำ</target>
+        </trans-unit>
+        <trans-unit id="TextColorBlue.Text" translate="yes" xml:space="preserve">
+          <source>Blue</source>
+          <target state="translated">ฟ้า</target>
+        </trans-unit>
+        <trans-unit id="TextColorGreen.Text" translate="yes" xml:space="preserve">
+          <source>Green</source>
+          <target state="translated">เขียว</target>
+        </trans-unit>
+        <trans-unit id="TextColorOrange.Text" translate="yes" xml:space="preserve">
+          <source>Orange</source>
+          <target state="translated">ส้ม</target>
+        </trans-unit>
+        <trans-unit id="TextColorPink.Text" translate="yes" xml:space="preserve">
+          <source>Pink</source>
+          <target state="translated">ชมพู</target>
+        </trans-unit>
+        <trans-unit id="TextColorWhite.Text" translate="yes" xml:space="preserve">
+          <source>White</source>
+          <target state="translated">ขาว</target>
+        </trans-unit>
+        <trans-unit id="TextColorYellow.Text" translate="yes" xml:space="preserve">
+          <source>Yellow</source>
+          <target state="translated">เหลือง</target>
+        </trans-unit>
+        <trans-unit id="DefaultFontColorCombobox.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Black</source>
+          <target state="translated">ดำ</target>
+        </trans-unit>
+        <trans-unit id="GeneralLaunchModeCombobox.PlaceholderText" translate="yes" xml:space="preserve">
+          <source>Default</source>
+          <target state="translated">ปกติ</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -26,10 +26,6 @@
           <source>Center</source>
           <target state="translated" state-qualifier="tm-suggestion">กึ่งกลาง</target>
         </trans-unit>
-        <trans-unit id="CmdFocusMode" translate="yes" xml:space="preserve">
-          <source>Focus Mode</source>
-          <target state="translated">โหมดเน้นพิมพ์</target>
-        </trans-unit>
         <trans-unit id="CmdNew.Label" translate="yes" xml:space="preserve">
           <source>New</source>
           <target state="translated">เริ่มใหม่</target>
@@ -80,7 +76,7 @@
         </trans-unit>
         <trans-unit id="Dark.Content" translate="yes" xml:space="preserve">
           <source>Dark</source>
-          <target state="translated">สีมืด</target>
+          <target state="translated">มืด</target>
         </trans-unit>
         <trans-unit id="DefaultFont.Text" translate="yes" xml:space="preserve">
           <source>Default Font</source>
@@ -104,11 +100,11 @@
         </trans-unit>
         <trans-unit id="GeneralDefaultType.Text" translate="yes" xml:space="preserve">
           <source>Default File Type</source>
-          <target state="translated">รูปแบบไฟล์เริ่มต้น</target>
+          <target state="translated">ฃนิดไฟล์เริ่มต้น</target>
         </trans-unit>
         <trans-unit id="GeneralLaunchMode.Text" translate="yes" xml:space="preserve">
           <source>Launch Mode</source>
-          <target state="translated">โหมดแอปเริ่มต้น</target>
+          <target state="translated">เริ่มแอปในโหมด</target>
         </trans-unit>
         <trans-unit id="GeneralToggleSwitch.OffContent" translate="yes" xml:space="preserve">
           <source>Off</source>
@@ -136,7 +132,7 @@
         </trans-unit>
         <trans-unit id="Light.Content" translate="yes" xml:space="preserve">
           <source>Light</source>
-          <target state="translated">สีสว่าง</target>
+          <target state="translated">สว่าง</target>
         </trans-unit>
         <trans-unit id="Paste.Label" translate="yes" xml:space="preserve">
           <source>Paste</source>
@@ -212,11 +208,11 @@
         </trans-unit>
         <trans-unit id="ShowAlignLeft.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align left</source>
-          <target state="translated">ซ่อนปุ่มจัดชิดขวา</target>
+          <target state="translated">ซ่อนปุ่มจัดชิดซ้าย</target>
         </trans-unit>
         <trans-unit id="ShowAlignLeft.OnContent" translate="yes" xml:space="preserve">
           <source>Show align left</source>
-          <target state="translated">แสดงปุ่มจัดชิดขวา</target>
+          <target state="translated">แสดงปุ่มจัดชิดซ้าย</target>
         </trans-unit>
         <trans-unit id="ShowAlignRight.OffContent" translate="yes" xml:space="preserve">
           <source>Hide align right</source>
@@ -269,6 +265,10 @@
         <trans-unit id="WordWrap.Text" translate="yes" xml:space="preserve">
           <source>Word Wrap</source>
           <target state="translated" state-qualifier="tm-suggestion">ตัดคำ</target>
+        </trans-unit>
+        <trans-unit id="CmdFocusMode.Label" translate="yes" xml:space="preserve">
+          <source>Focus Mode</source>
+          <target state="translated">เปิดโหมดเน้นพิมพ์</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -478,6 +478,14 @@
           <source>Justify text (Ctrl+J)</source>
           <target state="translated">จัดกลาง (Ctrl+J)</target>
         </trans-unit>
+        <trans-unit id="BlackPlaceholder" translate="yes" xml:space="preserve">
+          <source>Black</source>
+          <target state="new">Black</target>
+        </trans-unit>
+        <trans-unit id="WhitePlaceholder" translate="yes" xml:space="preserve">
+          <source>White</source>
+          <target state="new">White</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -1,0 +1,276 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en-US" target-language="th-TH" original="QUICK PAD/STRINGS/EN-US/RESOURCES.RESW" tool-id="MultilingualAppToolkit" product-name="n/a" product-version="n/a" build-num="n/a">
+    <header>
+      <tool tool-id="MultilingualAppToolkit" tool-name="Multilingual App Toolkit" tool-version="4.0.6914.0" tool-company="Microsoft" />
+    </header>
+    <body>
+      <group id="QUICK PAD/STRINGS/EN-US/RESOURCES.RESW" datatype="resx">
+        <trans-unit id="AppTheme.Text" translate="yes" xml:space="preserve">
+          <source>App theme</source>
+          <target state="translated">ธีมของแอป</target>
+        </trans-unit>
+        <trans-unit id="AutoSaveSwitch.Text" translate="yes" xml:space="preserve">
+          <source>Auto Save</source>
+          <target state="translated">บันทึกอัตโนมัติ</target>
+        </trans-unit>
+        <trans-unit id="Bold.Label" translate="yes" xml:space="preserve">
+          <source>Bold</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัวหนา</target>
+        </trans-unit>
+        <trans-unit id="BulletList.Label" translate="yes" xml:space="preserve">
+          <source>Bullets</source>
+          <target state="translated">สัญลักษณ์หัวข้อย่อย</target>
+        </trans-unit>
+        <trans-unit id="Center.Label" translate="yes" xml:space="preserve">
+          <source>Center</source>
+          <target state="translated" state-qualifier="tm-suggestion">กึ่งกลาง</target>
+        </trans-unit>
+        <trans-unit id="CmdFocusMode" translate="yes" xml:space="preserve">
+          <source>Focus Mode</source>
+          <target state="translated">โหมดเน้นพิมพ์</target>
+        </trans-unit>
+        <trans-unit id="CmdNew.Label" translate="yes" xml:space="preserve">
+          <source>New</source>
+          <target state="translated">เริ่มใหม่</target>
+        </trans-unit>
+        <trans-unit id="CmdOpen.Label" translate="yes" xml:space="preserve">
+          <source>Open</source>
+          <target state="translated" state-qualifier="tm-suggestion">เปิด</target>
+        </trans-unit>
+        <trans-unit id="CmdRedo.Label" translate="yes" xml:space="preserve">
+          <source>Redo</source>
+          <target state="translated" state-qualifier="tm-suggestion">ทำซ้ำ</target>
+        </trans-unit>
+        <trans-unit id="CmdReview.Label" translate="yes" xml:space="preserve">
+          <source>Review</source>
+          <target state="translated">รีวิว</target>
+        </trans-unit>
+        <trans-unit id="CmdSave.Label" translate="yes" xml:space="preserve">
+          <source>Save</source>
+          <target state="translated" state-qualifier="tm-suggestion">บันทึก</target>
+        </trans-unit>
+        <trans-unit id="CmdSettings.Label" translate="yes" xml:space="preserve">
+          <source>Settings</source>
+          <target state="translated">ตั้งค่า</target>
+        </trans-unit>
+        <trans-unit id="CmdShare.Label" translate="yes" xml:space="preserve">
+          <source>Share</source>
+          <target state="translated" state-qualifier="tm-suggestion">แชร์</target>
+        </trans-unit>
+        <trans-unit id="CmdUndo.Label" translate="yes" xml:space="preserve">
+          <source>Undo</source>
+          <target state="translated" state-qualifier="tm-suggestion">เลิกทำ</target>
+        </trans-unit>
+        <trans-unit id="CompactOverlay.Content" translate="yes" xml:space="preserve">
+          <source>On Top</source>
+          <target state="translated">ทับแอปอื่น</target>
+        </trans-unit>
+        <trans-unit id="Contribute.Content" translate="yes" xml:space="preserve">
+          <source>Contribute to the developer</source>
+          <target state="translated">บริจาคช่วยเหลือนักพัฒนา</target>
+        </trans-unit>
+        <trans-unit id="Copy.Label" translate="yes" xml:space="preserve">
+          <source>Copy</source>
+          <target state="translated" state-qualifier="tm-suggestion">คัดลอก</target>
+        </trans-unit>
+        <trans-unit id="Cut.Label" translate="yes" xml:space="preserve">
+          <source>Cut</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัด</target>
+        </trans-unit>
+        <trans-unit id="Dark.Content" translate="yes" xml:space="preserve">
+          <source>Dark</source>
+          <target state="translated">สีมืด</target>
+        </trans-unit>
+        <trans-unit id="DefaultFont.Text" translate="yes" xml:space="preserve">
+          <source>Default Font</source>
+          <target state="translated" state-qualifier="tm-suggestion">ฟอนต์เริ่มต้น</target>
+        </trans-unit>
+        <trans-unit id="DefaultFontColor.Text" translate="yes" xml:space="preserve">
+          <source>Default Font Color</source>
+          <target state="translated" state-qualifier="tm-suggestion">สีฟอนต์เริ่มต้น</target>
+        </trans-unit>
+        <trans-unit id="DefaultFontSize.Text" translate="yes" xml:space="preserve">
+          <source>Default Font Size</source>
+          <target state="translated">ขนาดฟอนต์เริ่มต้น</target>
+        </trans-unit>
+        <trans-unit id="DevelopedBy.Text" translate="yes" xml:space="preserve">
+          <source>Developed by Yair Aichenbaum</source>
+          <target state="translated">สร้างและพัฒนาโดย Yair Aichenbaum</target>
+        </trans-unit>
+        <trans-unit id="GeneralAutoSave.Text" translate="yes" xml:space="preserve">
+          <source>Auto Save</source>
+          <target state="translated">บันทึกอัตโนมัติ</target>
+        </trans-unit>
+        <trans-unit id="GeneralDefaultType.Text" translate="yes" xml:space="preserve">
+          <source>Default File Type</source>
+          <target state="translated">รูปแบบไฟล์เริ่มต้น</target>
+        </trans-unit>
+        <trans-unit id="GeneralLaunchMode.Text" translate="yes" xml:space="preserve">
+          <source>Launch Mode</source>
+          <target state="translated">โหมดแอปเริ่มต้น</target>
+        </trans-unit>
+        <trans-unit id="GeneralToggleSwitch.OffContent" translate="yes" xml:space="preserve">
+          <source>Off</source>
+          <target state="translated" state-qualifier="tm-suggestion">ปิด</target>
+        </trans-unit>
+        <trans-unit id="GeneralToggleSwitch.OnContent" translate="yes" xml:space="preserve">
+          <source>On</source>
+          <target state="translated" state-qualifier="tm-suggestion">เปิด</target>
+        </trans-unit>
+        <trans-unit id="IconDesignBy.Text" translate="yes" xml:space="preserve">
+          <source>Icon design by James Arney</source>
+          <target state="translated">ออกแบบไอคอนแอปโดย James Arney</target>
+        </trans-unit>
+        <trans-unit id="Italic.Label" translate="yes" xml:space="preserve">
+          <source>Italic</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัวเอียง</target>
+        </trans-unit>
+        <trans-unit id="Justify.Label" translate="yes" xml:space="preserve">
+          <source>Justify</source>
+          <target state="translated" state-qualifier="tm-suggestion">เต็มแนว</target>
+        </trans-unit>
+        <trans-unit id="Left.Label" translate="yes" xml:space="preserve">
+          <source>Left</source>
+          <target state="translated" state-qualifier="tm-suggestion">ซ้าย</target>
+        </trans-unit>
+        <trans-unit id="Light.Content" translate="yes" xml:space="preserve">
+          <source>Light</source>
+          <target state="translated">สีสว่าง</target>
+        </trans-unit>
+        <trans-unit id="Paste.Label" translate="yes" xml:space="preserve">
+          <source>Paste</source>
+          <target state="translated" state-qualifier="tm-suggestion">วาง</target>
+        </trans-unit>
+        <trans-unit id="RateAndReview.Content" translate="yes" xml:space="preserve">
+          <source>Rate and review</source>
+          <target state="translated" state-qualifier="tm-suggestion">ให้คะแนนและวิจารณ์</target>
+        </trans-unit>
+        <trans-unit id="Right.Label" translate="yes" xml:space="preserve">
+          <source>Right</source>
+          <target state="translated" state-qualifier="tm-suggestion">ขวา</target>
+        </trans-unit>
+        <trans-unit id="SaveDialog.Text" translate="yes" xml:space="preserve">
+          <source>Would you like to save your changes?</source>
+          <target state="translated" state-qualifier="tm-suggestion">คุณต้องการบันทึกการเปลี่ยนแปลงของคุณหรือไม่</target>
+        </trans-unit>
+        <trans-unit id="SaveDialogCancel.Content" translate="yes" xml:space="preserve">
+          <source>Cancel</source>
+          <target state="translated" state-qualifier="tm-suggestion">ยกเลิก</target>
+        </trans-unit>
+        <trans-unit id="SaveDialogNo.Content" translate="yes" xml:space="preserve">
+          <source>No</source>
+          <target state="translated" state-qualifier="tm-suggestion">ไม่ใช่</target>
+        </trans-unit>
+        <trans-unit id="SaveDialogYes.Content" translate="yes" xml:space="preserve">
+          <source>Yes</source>
+          <target state="translated" state-qualifier="tm-suggestion">ใช่</target>
+        </trans-unit>
+        <trans-unit id="SendFeedback.Content" translate="yes" xml:space="preserve">
+          <source>Send Feedback</source>
+          <target state="translated" state-qualifier="tm-suggestion">ส่งคำติชม</target>
+        </trans-unit>
+        <trans-unit id="SettingsPivot.Title" translate="yes" xml:space="preserve">
+          <source>Settings</source>
+          <target state="translated" state-qualifier="tm-suggestion">การตั้งค่า</target>
+        </trans-unit>
+        <trans-unit id="SettingsTab1.Header" translate="yes" xml:space="preserve">
+          <source>General</source>
+          <target state="translated" state-qualifier="tm-suggestion">ทั่วไป</target>
+        </trans-unit>
+        <trans-unit id="SettingsTab2.Header" translate="yes" xml:space="preserve">
+          <source>Theme</source>
+          <target state="translated" state-qualifier="tm-suggestion">ธีม</target>
+        </trans-unit>
+        <trans-unit id="SettingsTab3.Header" translate="yes" xml:space="preserve">
+          <source>Font</source>
+          <target state="translated" state-qualifier="tm-suggestion">แบบอักษร</target>
+        </trans-unit>
+        <trans-unit id="SettingsTab4.Header" translate="yes" xml:space="preserve">
+          <source>Toolbar</source>
+          <target state="translated" state-qualifier="tm-suggestion">แถบเครื่องมือ</target>
+        </trans-unit>
+        <trans-unit id="SettingsTab5.Header" translate="yes" xml:space="preserve">
+          <source>About</source>
+          <target state="translated" state-qualifier="tm-suggestion">เกี่ยวกับ</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignCenter.OffContent" translate="yes" xml:space="preserve">
+          <source>Hide align center</source>
+          <target state="translated">ซ่อนปุ่มจัดกลาง</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignCenter.OnContent" translate="yes" xml:space="preserve">
+          <source>Show align center</source>
+          <target state="translated">แสดงปุ่มจัดกลาง</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignJustify.OffContent" translate="yes" xml:space="preserve">
+          <source>Hide align justify</source>
+          <target state="translated">ซ่อนปุ่มจัดเต็มแนว</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignJustify.OnContent" translate="yes" xml:space="preserve">
+          <source>Show align justify</source>
+          <target state="translated">แสดงปุ่มจัดเต็มแนว</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignLeft.OffContent" translate="yes" xml:space="preserve">
+          <source>Hide align left</source>
+          <target state="translated">ซ่อนปุ่มจัดชิดขวา</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignLeft.OnContent" translate="yes" xml:space="preserve">
+          <source>Show align left</source>
+          <target state="translated">แสดงปุ่มจัดชิดขวา</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignRight.OffContent" translate="yes" xml:space="preserve">
+          <source>Hide align right</source>
+          <target state="translated">ซ่อนปุ่มจัดชิดขวา</target>
+        </trans-unit>
+        <trans-unit id="ShowAlignRight.OnContent" translate="yes" xml:space="preserve">
+          <source>Show align right</source>
+          <target state="translated">แสดงปุ่มจัดชิดขวา</target>
+        </trans-unit>
+        <trans-unit id="ShowBullets.OffContent" translate="yes" xml:space="preserve">
+          <source>Hide bullet list</source>
+          <target state="translated">ซ่อนปุ่มสัญลักษณ์หัวข้อ</target>
+        </trans-unit>
+        <trans-unit id="ShowBullets.OnContent" translate="yes" xml:space="preserve">
+          <source>Show bullet list</source>
+          <target state="translated">แสดงปุ่มสัญลักษณ์หัวข้อ</target>
+        </trans-unit>
+        <trans-unit id="ShowStrikethrough.OffContent" translate="yes" xml:space="preserve">
+          <source>Hide strikethrough option</source>
+          <target state="translated">ซ่อนปุ่มขีดทับ</target>
+        </trans-unit>
+        <trans-unit id="ShowStrikethrough.OnContent" translate="yes" xml:space="preserve">
+          <source>Show strikethrough option</source>
+          <target state="translated">แสดงปุ่มขีดทับ</target>
+        </trans-unit>
+        <trans-unit id="SizeDown.Label" translate="yes" xml:space="preserve">
+          <source>Size Down</source>
+          <target state="translated">ย่อขนาด</target>
+        </trans-unit>
+        <trans-unit id="SizeUp.Label" translate="yes" xml:space="preserve">
+          <source>Size Up</source>
+          <target state="translated">ขยายขนาด</target>
+        </trans-unit>
+        <trans-unit id="SpellCheck.Text" translate="yes" xml:space="preserve">
+          <source>Spell Check</source>
+          <target state="translated">เช็คคำผิด</target>
+        </trans-unit>
+        <trans-unit id="Strikethrough.Label" translate="yes" xml:space="preserve">
+          <source>Strikethrough</source>
+          <target state="translated" state-qualifier="tm-suggestion">ขีดทับ</target>
+        </trans-unit>
+        <trans-unit id="SystemDefault.Content" translate="yes" xml:space="preserve">
+          <source>System Default</source>
+          <target state="translated" state-qualifier="tm-suggestion">ค่าเริ่มต้นระบบ</target>
+        </trans-unit>
+        <trans-unit id="Underline.Label" translate="yes" xml:space="preserve">
+          <source>Underline</source>
+          <target state="translated" state-qualifier="tm-suggestion">ขีดเส้นใต้</target>
+        </trans-unit>
+        <trans-unit id="WordWrap.Text" translate="yes" xml:space="preserve">
+          <source>Word Wrap</source>
+          <target state="translated" state-qualifier="tm-suggestion">ตัดคำ</target>
+        </trans-unit>
+      </group>
+    </body>
+  </file>
+</xliff>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -270,6 +270,46 @@
           <source>Focus Mode</source>
           <target state="translated">เปิดโหมดเน้นพิมพ์</target>
         </trans-unit>
+        <trans-unit id="ErrorDialogContent" translate="yes" xml:space="preserve">
+          <source>Sorry, Quick Pad couldn't open the file.</source>
+          <target state="translated">ไม่สามารถเปิดไฟล์นี้ได้</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogOk" translate="yes" xml:space="preserve">
+          <source>Ok</source>
+          <target state="translated">ตกลง</target>
+        </trans-unit>
+        <trans-unit id="ErrorDialogTitle" translate="yes" xml:space="preserve">
+          <source>File open error</source>
+          <target state="translated">เกิดข้อผิดพลาด</target>
+        </trans-unit>
+        <trans-unit id="NewDocument" translate="yes" xml:space="preserve">
+          <source>New Document</source>
+          <target state="translated">เอกสารใหม่</target>
+        </trans-unit>
+        <trans-unit id="NewUserFeedbackContent" translate="yes" xml:space="preserve">
+          <source>Please consider leaving a review for Quick Pad in the store.</source>
+          <target state="translated">กรุณาส่งข้อคิดเห็นหรือคำวิจารณ์ให้กับแอปของเราใน Store</target>
+        </trans-unit>
+        <trans-unit id="NewUserFeedbackNo" translate="yes" xml:space="preserve">
+          <source>No</source>
+          <target state="translated">ปิด</target>
+        </trans-unit>
+        <trans-unit id="NewUserFeedbackTitle" translate="yes" xml:space="preserve">
+          <source>Do you enjoy using Quick Pad?</source>
+          <target state="translated">คุณรู้สึกยังไงบ้างกับแอป Quick Pad?</target>
+        </trans-unit>
+        <trans-unit id="NewUserFeedbackYes" translate="yes" xml:space="preserve">
+          <source>Yes</source>
+          <target state="translated">ตกลง</target>
+        </trans-unit>
+        <trans-unit id="NothingToShare" translate="yes" xml:space="preserve">
+          <source>Nothing to share, type something in order to share it.</source>
+          <target state="translated">ไม่มีอะไรจะแชร์ กรุณาพิมพ์อะไรสักอย่างเพื่อจะแชร์</target>
+        </trans-unit>
+        <trans-unit id="VersionFormat" translate="yes" xml:space="preserve">
+          <source>Version: {0}.{1}.{2}.{3}</source>
+          <target state="translated">เวอร์ชั่น: {0}.{1}.{2}.{3}</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -84,7 +84,7 @@
         </trans-unit>
         <trans-unit id="DefaultFontColor.Text" translate="yes" xml:space="preserve">
           <source>Default Font Color</source>
-          <target state="translated" state-qualifier="tm-suggestion">สีฟอนต์เริ่มต้น</target>
+          <target state="translated">สีตัวอักษรเริ่มต้น</target>
         </trans-unit>
         <trans-unit id="DefaultFontSize.Text" translate="yes" xml:space="preserve">
           <source>Default Font Size</source>
@@ -385,6 +385,98 @@
         <trans-unit id="GeneralLaunchModeCombobox.PlaceholderText" translate="yes" xml:space="preserve">
           <source>Default</source>
           <target state="translated">ปกติ</target>
+        </trans-unit>
+        <trans-unit id="BoldTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Bold (Ctrl+B)</source>
+          <target state="translated">ตัวหนา (Ctrl+B)</target>
+        </trans-unit>
+        <trans-unit id="BulletListTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Toggle Bullets</source>
+          <target state="translated">เปิดใช้สัญลักษณ์หัวข้อ</target>
+        </trans-unit>
+        <trans-unit id="CenterTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Align center (Ctrl+E)</source>
+          <target state="translated">จัดกลาง (Ctrl+E)</target>
+        </trans-unit>
+        <trans-unit id="CmdNewTooltip.Text" translate="yes" xml:space="preserve">
+          <source>New</source>
+          <target state="translated">เริ่มใหม่</target>
+        </trans-unit>
+        <trans-unit id="CmdOpenTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Open (Ctrl+O)</source>
+          <target state="translated">เปิด (Ctrl+O)</target>
+        </trans-unit>
+        <trans-unit id="CmdRedoTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Redo (Ctrl+Y)</source>
+          <target state="translated">ทำซ้ำ (Ctrl+Y)</target>
+        </trans-unit>
+        <trans-unit id="CmdSaveTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Save (Ctrl+S)</source>
+          <target state="translated">บันทึก (Ctrl+S)</target>
+        </trans-unit>
+        <trans-unit id="CmdSettingsTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Settings</source>
+          <target state="translated">ตั้งค่า</target>
+        </trans-unit>
+        <trans-unit id="CmdShareTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Share the file you are working on.</source>
+          <target state="translated">ส่งไฟล์นี้ให้เพื่อนของคุณ</target>
+        </trans-unit>
+        <trans-unit id="CmdUndoTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Undo (Ctrl+Z)</source>
+          <target state="translated">เลิกทำ (Ctrl+Z)</target>
+        </trans-unit>
+        <trans-unit id="CopyTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Copy (Ctrl+C)</source>
+          <target state="translated">คัดลอก (Ctrl+C)</target>
+        </trans-unit>
+        <trans-unit id="CutTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Cut (Ctrl+X)</source>
+          <target state="translated">ตัด (Ctrl+X)</target>
+        </trans-unit>
+        <trans-unit id="ExitFocusMode.Text" translate="yes" xml:space="preserve">
+          <source>Exit Focus Mode</source>
+          <target state="translated">ออกจากโหมดเน้นพิมพ์</target>
+        </trans-unit>
+        <trans-unit id="ItalicTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Italic (Ctrl+I)</source>
+          <target state="translated">ตัวเอียง (Ctrl+I)</target>
+        </trans-unit>
+        <trans-unit id="LeftTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Align left (Ctrl+L)</source>
+          <target state="translated">จัดชิดซ้าย (Ctrl+L)</target>
+        </trans-unit>
+        <trans-unit id="PasteTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Paste (Ctrl+V)</source>
+          <target state="translated">วาง (Ctrl+V)</target>
+        </trans-unit>
+        <trans-unit id="RightTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Align right (Ctrl+R)</source>
+          <target state="translated">จัดชิดขวา (Ctrl+R)</target>
+        </trans-unit>
+        <trans-unit id="SizeDownTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Size Down</source>
+          <target state="translated">ย่อขนาด</target>
+        </trans-unit>
+        <trans-unit id="SizeUpTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Size Up</source>
+          <target state="translated">ขยายขนาด</target>
+        </trans-unit>
+        <trans-unit id="StrikethroughTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Strikethrough</source>
+          <target state="translated">ขีดทับ</target>
+        </trans-unit>
+        <trans-unit id="TextColorTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Font Color</source>
+          <target state="translated">สีตัวอักษร</target>
+        </trans-unit>
+        <trans-unit id="UnderlineTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Underline (Ctrl+U)</source>
+          <target state="translated">ขีดเส้นใต้ (Ctrl+U)</target>
+        </trans-unit>
+        <trans-unit id="JustifyTooltip.Text" translate="yes" xml:space="preserve">
+          <source>Justify text (Ctrl+J)</source>
+          <target state="translated">จัดกลาง (Ctrl+J)</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/Quick Pad.csproj
+++ b/Quick Pad/Quick Pad.csproj
@@ -218,11 +218,8 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AdDuplexWin10">
-      <Version>10.2.0.6</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
-      <Version>1.14.0</Version>
+      <Version>2.1.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
       <Version>2.1.1</Version>
@@ -238,9 +235,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="Microsoft.Advertising.Xaml, Version=10.0">
-      <Name>Microsoft Advertising SDK for XAML</Name>
-    </SDKReference>
     <SDKReference Include="Microsoft.Services.Store.Engagement, Version=10.0">
       <Name>Microsoft Engagement Framework</Name>
     </SDKReference>

--- a/Quick Pad/Quick Pad.csproj
+++ b/Quick Pad/Quick Pad.csproj
@@ -194,6 +194,7 @@
     <Content Include="Assets\Square44x44Logo.scale-200.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/Quick Pad/Quick Pad.csproj
+++ b/Quick Pad/Quick Pad.csproj
@@ -194,6 +194,7 @@
     <Content Include="Assets\Square44x44Logo.scale-200.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <PRIResource Include="Strings\th-TH\Resources.resw" />
     <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>

--- a/Quick Pad/Quick Pad.csproj
+++ b/Quick Pad/Quick Pad.csproj
@@ -123,6 +123,12 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
+  <PropertyGroup Label="MultilingualAppToolkit">
+    <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
+    <MultilingualFallbackLanguage>en-US</MultilingualFallbackLanguage>
+    <TranslationReport Condition="'$(Configuration)' == 'Release'">true</TranslationReport>
+    <SuppressPseudoWarning Condition="'$(Configuration)' == 'Debug'">true</SuppressPseudoWarning>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
@@ -242,11 +248,17 @@
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <XliffResource Include="MultilingualResources\Quick Pad.th-TH.xlf" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\v$(MultilingualAppToolkitVersion)\Microsoft.Multilingual.PriResources.targets')" />
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.PriResources.targets')" Label="MultilingualAppToolkit">
+    <Warning Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio, please check to ensure that toolkit is properly installed." />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -123,6 +123,9 @@
   <data name="AutoSaveSwitch.Text" xml:space="preserve">
     <value>Auto Save</value>
   </data>
+  <data name="BlackPlaceholder" xml:space="preserve">
+    <value>Black</value>
+  </data>
   <data name="Bold.Label" xml:space="preserve">
     <value>Bold</value>
   </data>
@@ -467,6 +470,9 @@
   </data>
   <data name="VersionFormat" xml:space="preserve">
     <value>Version: {0}.{1}.{2}.{3}</value>
+  </data>
+  <data name="WhitePlaceholder" xml:space="preserve">
+    <value>White</value>
   </data>
   <data name="WordWrap.Text" xml:space="preserve">
     <value>Word Wrap</value>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -126,11 +126,20 @@
   <data name="Bold.Label" xml:space="preserve">
     <value>Bold</value>
   </data>
+  <data name="BoldTooltip.Text" xml:space="preserve">
+    <value>Bold (Ctrl+B)</value>
+  </data>
   <data name="BulletList.Label" xml:space="preserve">
     <value>Bullets</value>
   </data>
+  <data name="BulletListTooltip.Text" xml:space="preserve">
+    <value>Toggle Bullets</value>
+  </data>
   <data name="Center.Label" xml:space="preserve">
     <value>Center</value>
+  </data>
+  <data name="CenterTooltip.Text" xml:space="preserve">
+    <value>Align center (Ctrl+E)</value>
   </data>
   <data name="CmdFocusMode.Label" xml:space="preserve">
     <value>Focus Mode</value>
@@ -138,11 +147,20 @@
   <data name="CmdNew.Label" xml:space="preserve">
     <value>New</value>
   </data>
+  <data name="CmdNewTooltip.Text" xml:space="preserve">
+    <value>New</value>
+  </data>
   <data name="CmdOpen.Label" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="CmdOpenTooltip.Text" xml:space="preserve">
+    <value>Open (Ctrl+O)</value>
+  </data>
   <data name="CmdRedo.Label" xml:space="preserve">
     <value>Redo</value>
+  </data>
+  <data name="CmdRedoTooltip.Text" xml:space="preserve">
+    <value>Redo (Ctrl+Y)</value>
   </data>
   <data name="CmdReview.Label" xml:space="preserve">
     <value>Review</value>
@@ -150,14 +168,26 @@
   <data name="CmdSave.Label" xml:space="preserve">
     <value>Save</value>
   </data>
+  <data name="CmdSaveTooltip.Text" xml:space="preserve">
+    <value>Save (Ctrl+S)</value>
+  </data>
   <data name="CmdSettings.Label" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="CmdSettingsTooltip.Text" xml:space="preserve">
     <value>Settings</value>
   </data>
   <data name="CmdShare.Label" xml:space="preserve">
     <value>Share</value>
   </data>
+  <data name="CmdShareTooltip.Text" xml:space="preserve">
+    <value>Share the file you are working on.</value>
+  </data>
   <data name="CmdUndo.Label" xml:space="preserve">
     <value>Undo</value>
+  </data>
+  <data name="CmdUndoTooltip.Text" xml:space="preserve">
+    <value>Undo (Ctrl+Z)</value>
   </data>
   <data name="CompactOverlay.Content" xml:space="preserve">
     <value>On Top</value>
@@ -168,8 +198,14 @@
   <data name="Copy.Label" xml:space="preserve">
     <value>Copy</value>
   </data>
+  <data name="CopyTooltip.Text" xml:space="preserve">
+    <value>Copy (Ctrl+C)</value>
+  </data>
   <data name="Cut.Label" xml:space="preserve">
     <value>Cut</value>
+  </data>
+  <data name="CutTooltip.Text" xml:space="preserve">
+    <value>Cut (Ctrl+X)</value>
   </data>
   <data name="Dark.Content" xml:space="preserve">
     <value>Dark</value>
@@ -197,6 +233,9 @@
   </data>
   <data name="ErrorDialogTitle" xml:space="preserve">
     <value>File open error</value>
+  </data>
+  <data name="ExitFocusMode.Text" xml:space="preserve">
+    <value>Exit Focus Mode</value>
   </data>
   <data name="FontColorBlack.Content" xml:space="preserve">
     <value>Black</value>
@@ -243,8 +282,14 @@
   <data name="Italic.Label" xml:space="preserve">
     <value>Italic</value>
   </data>
+  <data name="ItalicTooltip.Text" xml:space="preserve">
+    <value>Italic (Ctrl+I)</value>
+  </data>
   <data name="Justify.Label" xml:space="preserve">
     <value>Justify</value>
+  </data>
+  <data name="JustifyTooltip.Text" xml:space="preserve">
+    <value>Justify text (Ctrl+J)</value>
   </data>
   <data name="LaunchModeDefault.Content" xml:space="preserve">
     <value>Default</value>
@@ -257,6 +302,9 @@
   </data>
   <data name="Left.Label" xml:space="preserve">
     <value>Left</value>
+  </data>
+  <data name="LeftTooltip.Text" xml:space="preserve">
+    <value>Align left (Ctrl+L)</value>
   </data>
   <data name="Light.Content" xml:space="preserve">
     <value>Light</value>
@@ -282,11 +330,17 @@
   <data name="Paste.Label" xml:space="preserve">
     <value>Paste</value>
   </data>
+  <data name="PasteTooltip.Text" xml:space="preserve">
+    <value>Paste (Ctrl+V)</value>
+  </data>
   <data name="RateAndReview.Content" xml:space="preserve">
     <value>Rate and review</value>
   </data>
   <data name="Right.Label" xml:space="preserve">
     <value>Right</value>
+  </data>
+  <data name="RightTooltip.Text" xml:space="preserve">
+    <value>Align right (Ctrl+R)</value>
   </data>
   <data name="SaveDialog.Text" xml:space="preserve">
     <value>Would you like to save your changes?</value>
@@ -360,13 +414,22 @@
   <data name="SizeDown.Label" xml:space="preserve">
     <value>Size Down</value>
   </data>
+  <data name="SizeDownTooltip.Text" xml:space="preserve">
+    <value>Size Down</value>
+  </data>
   <data name="SizeUp.Label" xml:space="preserve">
+    <value>Size Up</value>
+  </data>
+  <data name="SizeUpTooltip.Text" xml:space="preserve">
     <value>Size Up</value>
   </data>
   <data name="SpellCheck.Text" xml:space="preserve">
     <value>Spell Check</value>
   </data>
   <data name="Strikethrough.Label" xml:space="preserve">
+    <value>Strikethrough</value>
+  </data>
+  <data name="StrikethroughTooltip.Text" xml:space="preserve">
     <value>Strikethrough</value>
   </data>
   <data name="SystemDefault.Content" xml:space="preserve">
@@ -387,6 +450,9 @@
   <data name="TextColorPink.Text" xml:space="preserve">
     <value>Pink</value>
   </data>
+  <data name="TextColorTooltip.Text" xml:space="preserve">
+    <value>Font Color</value>
+  </data>
   <data name="TextColorWhite.Text" xml:space="preserve">
     <value>White</value>
   </data>
@@ -395,6 +461,9 @@
   </data>
   <data name="Underline.Label" xml:space="preserve">
     <value>Underline</value>
+  </data>
+  <data name="UnderlineTooltip.Text" xml:space="preserve">
+    <value>Underline (Ctrl+U)</value>
   </data>
   <data name="VersionFormat" xml:space="preserve">
     <value>Version: {0}.{1}.{2}.{3}</value>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -132,7 +132,7 @@
   <data name="Center.Label" xml:space="preserve">
     <value>Center</value>
   </data>
-  <data name="CmdFocusMode" xml:space="preserve">
+  <data name="CmdFocusMode.Label" xml:space="preserve">
     <value>Focus Mode</value>
   </data>
   <data name="CmdNew.Label" xml:space="preserve">

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -180,6 +180,9 @@
   <data name="DefaultFontColor.Text" xml:space="preserve">
     <value>Default Font Color</value>
   </data>
+  <data name="DefaultFontColorCombobox.PlaceholderText" xml:space="preserve">
+    <value>Black</value>
+  </data>
   <data name="DefaultFontSize.Text" xml:space="preserve">
     <value>Default Font Size</value>
   </data>
@@ -195,6 +198,27 @@
   <data name="ErrorDialogTitle" xml:space="preserve">
     <value>File open error</value>
   </data>
+  <data name="FontColorBlack.Content" xml:space="preserve">
+    <value>Black</value>
+  </data>
+  <data name="FontColorLightGreen.Content" xml:space="preserve">
+    <value>Green</value>
+  </data>
+  <data name="FontColorLightPink.Content" xml:space="preserve">
+    <value>Pink</value>
+  </data>
+  <data name="FontColorLightSalmon.Content" xml:space="preserve">
+    <value>Orange</value>
+  </data>
+  <data name="FontColorLightYellow.Content" xml:space="preserve">
+    <value>Yellow</value>
+  </data>
+  <data name="FontColorSkyBlue.Content" xml:space="preserve">
+    <value>Blue</value>
+  </data>
+  <data name="FontColorWhite.Content" xml:space="preserve">
+    <value>White</value>
+  </data>
   <data name="GeneralAutoSave.Text" xml:space="preserve">
     <value>Auto Save</value>
   </data>
@@ -203,6 +227,9 @@
   </data>
   <data name="GeneralLaunchMode.Text" xml:space="preserve">
     <value>Launch Mode</value>
+  </data>
+  <data name="GeneralLaunchModeCombobox.PlaceholderText" xml:space="preserve">
+    <value>Default</value>
   </data>
   <data name="GeneralToggleSwitch.OffContent" xml:space="preserve">
     <value>Off</value>
@@ -218,6 +245,15 @@
   </data>
   <data name="Justify.Label" xml:space="preserve">
     <value>Justify</value>
+  </data>
+  <data name="LaunchModeDefault.Content" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="LaunchModeFocus.Content" xml:space="preserve">
+    <value>Focus</value>
+  </data>
+  <data name="LaunchModeOnTop.Content" xml:space="preserve">
+    <value>On Top</value>
   </data>
   <data name="Left.Label" xml:space="preserve">
     <value>Left</value>
@@ -335,6 +371,27 @@
   </data>
   <data name="SystemDefault.Content" xml:space="preserve">
     <value>System Default</value>
+  </data>
+  <data name="TextColorBlack.Text" xml:space="preserve">
+    <value>Black</value>
+  </data>
+  <data name="TextColorBlue.Text" xml:space="preserve">
+    <value>Blue</value>
+  </data>
+  <data name="TextColorGreen.Text" xml:space="preserve">
+    <value>Green</value>
+  </data>
+  <data name="TextColorOrange.Text" xml:space="preserve">
+    <value>Orange</value>
+  </data>
+  <data name="TextColorPink.Text" xml:space="preserve">
+    <value>Pink</value>
+  </data>
+  <data name="TextColorWhite.Text" xml:space="preserve">
+    <value>White</value>
+  </data>
+  <data name="TextColorYellow.Text" xml:space="preserve">
+    <value>Yellow</value>
   </data>
   <data name="Underline.Label" xml:space="preserve">
     <value>Underline</value>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -126,20 +126,11 @@
   <data name="Bold.Label" xml:space="preserve">
     <value>Bold</value>
   </data>
-  <data name="Bold.TooltipService.Tooltip" xml:space="preserve">
-    <value>Bold (Ctrl+B)</value>
-  </data>
   <data name="BulletList.Label" xml:space="preserve">
     <value>Bullets</value>
   </data>
-  <data name="BulletList.TooltipService.Tooltip" xml:space="preserve">
-    <value>Toggle Bullets</value>
-  </data>
   <data name="Center.Label" xml:space="preserve">
     <value>Center</value>
-  </data>
-  <data name="Center.TooltipService.Tooltip" xml:space="preserve">
-    <value>Aligh center (Ctrl+E)</value>
   </data>
   <data name="CmdFocusMode" xml:space="preserve">
     <value>Focus Mode</value>
@@ -147,47 +138,26 @@
   <data name="CmdNew.Label" xml:space="preserve">
     <value>New</value>
   </data>
-  <data name="CmdNew.TooltipService.Tooltip" xml:space="preserve">
-    <value>New</value>
-  </data>
   <data name="CmdOpen.Label" xml:space="preserve">
     <value>Open</value>
-  </data>
-  <data name="CmdOpen.TooltipService.Tooltip" xml:space="preserve">
-    <value>Open (Ctrl+O)</value>
   </data>
   <data name="CmdRedo.Label" xml:space="preserve">
     <value>Redo</value>
   </data>
-  <data name="CmdRedo.TooltipService.Tooltip" xml:space="preserve">
-    <value>Redo (Ctrl+Y)</value>
-  </data>
-  <data name="CmdReview" xml:space="preserve">
+  <data name="CmdReview.Label" xml:space="preserve">
     <value>Review</value>
   </data>
   <data name="CmdSave.Label" xml:space="preserve">
     <value>Save</value>
   </data>
-  <data name="CmdSave.TooltipService.Tooltip" xml:space="preserve">
-    <value>Save (Ctrl+S)</value>
-  </data>
-  <data name="CmdSettings" xml:space="preserve">
+  <data name="CmdSettings.Label" xml:space="preserve">
     <value>Settings</value>
   </data>
-  <data name="CmdSettings.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Settings</value>
-  </data>
-  <data name="CmdShare" xml:space="preserve">
+  <data name="CmdShare.Label" xml:space="preserve">
     <value>Share</value>
-  </data>
-  <data name="CmdShare.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Share the file you are working on.</value>
   </data>
   <data name="CmdUndo.Label" xml:space="preserve">
     <value>Undo</value>
-  </data>
-  <data name="CmdUndo.TooltipService.Tooltip" xml:space="preserve">
-    <value>Undo (Ctrl+Z)</value>
   </data>
   <data name="CompactOverlay.Content" xml:space="preserve">
     <value>On Top</value>
@@ -198,14 +168,8 @@
   <data name="Copy.Label" xml:space="preserve">
     <value>Copy</value>
   </data>
-  <data name="Copy.TooltipService.Tooltip" xml:space="preserve">
-    <value>Copy (Ctrl+C)</value>
-  </data>
   <data name="Cut.Label" xml:space="preserve">
     <value>Cut</value>
-  </data>
-  <data name="Cut.TooltipService.Tooltip" xml:space="preserve">
-    <value>Cut (Ctrl+C)</value>
   </data>
   <data name="Dark.Content" xml:space="preserve">
     <value>Dark</value>
@@ -243,20 +207,11 @@
   <data name="Italic.Label" xml:space="preserve">
     <value>Italic</value>
   </data>
-  <data name="Italic.TooltipService.Tooltip" xml:space="preserve">
-    <value>Italic (Ctrl+I)</value>
-  </data>
   <data name="Justify.Label" xml:space="preserve">
     <value>Justify</value>
   </data>
-  <data name="Justify.TooltipService.Tooltip" xml:space="preserve">
-    <value>Align justify (Ctrl+J)</value>
-  </data>
   <data name="Left.Label" xml:space="preserve">
     <value>Left</value>
-  </data>
-  <data name="Left.TooltipService.Tooltip" xml:space="preserve">
-    <value>Align left (Ctrl+L)</value>
   </data>
   <data name="Light.Content" xml:space="preserve">
     <value>Light</value>
@@ -264,17 +219,11 @@
   <data name="Paste.Label" xml:space="preserve">
     <value>Paste</value>
   </data>
-  <data name="Paste.TooltipService.Tooltip" xml:space="preserve">
-    <value>Paste (Ctrl+P)</value>
-  </data>
   <data name="RateAndReview.Content" xml:space="preserve">
     <value>Rate and review</value>
   </data>
   <data name="Right.Label" xml:space="preserve">
     <value>Right</value>
-  </data>
-  <data name="Right.TooltipService.Tooltip" xml:space="preserve">
-    <value>Align right (Ctrl+R)</value>
   </data>
   <data name="SaveDialog.Text" xml:space="preserve">
     <value>Would you like to save your changes?</value>
@@ -348,13 +297,7 @@
   <data name="SizeDown.Label" xml:space="preserve">
     <value>Size Down</value>
   </data>
-  <data name="SizeDown.TooltipService.Tooltip" xml:space="preserve">
-    <value>Size Down</value>
-  </data>
   <data name="SizeUp.Label" xml:space="preserve">
-    <value>Size Up</value>
-  </data>
-  <data name="SizeUp.TooltipService.Tooltip" xml:space="preserve">
     <value>Size Up</value>
   </data>
   <data name="SpellCheck.Text" xml:space="preserve">
@@ -363,20 +306,11 @@
   <data name="Strikethrough.Label" xml:space="preserve">
     <value>Strikethrough</value>
   </data>
-  <data name="Strikethrough.TooltipService.Tooltip" xml:space="preserve">
-    <value>Strikethrough</value>
-  </data>
   <data name="SystemDefault.Content" xml:space="preserve">
     <value>System Default</value>
   </data>
-  <data name="TextColor.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Font Color</value>
-  </data>
   <data name="Underline.Label" xml:space="preserve">
     <value>Underline</value>
-  </data>
-  <data name="Underline.TooltipService.Tooltip" xml:space="preserve">
-    <value>Underline (Ctrl+U)</value>
   </data>
   <data name="WordWrap.Text" xml:space="preserve">
     <value>Word Wrap</value>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -186,6 +186,15 @@
   <data name="DevelopedBy.Text" xml:space="preserve">
     <value>Developed by Yair Aichenbaum</value>
   </data>
+  <data name="ErrorDialogContent" xml:space="preserve">
+    <value>Sorry, Quick Pad couldn't open the file.</value>
+  </data>
+  <data name="ErrorDialogOk" xml:space="preserve">
+    <value>Ok</value>
+  </data>
+  <data name="ErrorDialogTitle" xml:space="preserve">
+    <value>File open error</value>
+  </data>
   <data name="GeneralAutoSave.Text" xml:space="preserve">
     <value>Auto Save</value>
   </data>
@@ -215,6 +224,24 @@
   </data>
   <data name="Light.Content" xml:space="preserve">
     <value>Light</value>
+  </data>
+  <data name="NewDocument" xml:space="preserve">
+    <value>New Document</value>
+  </data>
+  <data name="NewUserFeedbackContent" xml:space="preserve">
+    <value>Please consider leaving a review for Quick Pad in the store.</value>
+  </data>
+  <data name="NewUserFeedbackNo" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="NewUserFeedbackTitle" xml:space="preserve">
+    <value>Do you enjoy using Quick Pad?</value>
+  </data>
+  <data name="NewUserFeedbackYes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="NothingToShare" xml:space="preserve">
+    <value>Nothing to share, type something in order to share it.</value>
   </data>
   <data name="Paste.Label" xml:space="preserve">
     <value>Paste</value>
@@ -311,6 +338,9 @@
   </data>
   <data name="Underline.Label" xml:space="preserve">
     <value>Underline</value>
+  </data>
+  <data name="VersionFormat" xml:space="preserve">
+    <value>Version: {0}.{1}.{2}.{3}</value>
   </data>
   <data name="WordWrap.Text" xml:space="preserve">
     <value>Word Wrap</value>

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -1,0 +1,384 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTheme.Text" xml:space="preserve">
+    <value>App theme</value>
+  </data>
+  <data name="AutoSaveSwitch.Text" xml:space="preserve">
+    <value>Auto Save</value>
+  </data>
+  <data name="Bold.Label" xml:space="preserve">
+    <value>Bold</value>
+  </data>
+  <data name="Bold.TooltipService.Tooltip" xml:space="preserve">
+    <value>Bold (Ctrl+B)</value>
+  </data>
+  <data name="BulletList.Label" xml:space="preserve">
+    <value>Bullets</value>
+  </data>
+  <data name="BulletList.TooltipService.Tooltip" xml:space="preserve">
+    <value>Toggle Bullets</value>
+  </data>
+  <data name="Center.Label" xml:space="preserve">
+    <value>Center</value>
+  </data>
+  <data name="Center.TooltipService.Tooltip" xml:space="preserve">
+    <value>Aligh center (Ctrl+E)</value>
+  </data>
+  <data name="CmdFocusMode" xml:space="preserve">
+    <value>Focus Mode</value>
+  </data>
+  <data name="CmdNew.Label" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="CmdNew.TooltipService.Tooltip" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="CmdOpen.Label" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="CmdOpen.TooltipService.Tooltip" xml:space="preserve">
+    <value>Open (Ctrl+O)</value>
+  </data>
+  <data name="CmdRedo.Label" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="CmdRedo.TooltipService.Tooltip" xml:space="preserve">
+    <value>Redo (Ctrl+Y)</value>
+  </data>
+  <data name="CmdReview" xml:space="preserve">
+    <value>Review</value>
+  </data>
+  <data name="CmdSave.Label" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="CmdSave.TooltipService.Tooltip" xml:space="preserve">
+    <value>Save (Ctrl+S)</value>
+  </data>
+  <data name="CmdSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="CmdSettings.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="CmdShare" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="CmdShare.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Share the file you are working on.</value>
+  </data>
+  <data name="CmdUndo.Label" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="CmdUndo.TooltipService.Tooltip" xml:space="preserve">
+    <value>Undo (Ctrl+Z)</value>
+  </data>
+  <data name="CompactOverlay.Content" xml:space="preserve">
+    <value>On Top</value>
+  </data>
+  <data name="Contribute.Content" xml:space="preserve">
+    <value>Contribute to the developer</value>
+  </data>
+  <data name="Copy.Label" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="Copy.TooltipService.Tooltip" xml:space="preserve">
+    <value>Copy (Ctrl+C)</value>
+  </data>
+  <data name="Cut.Label" xml:space="preserve">
+    <value>Cut</value>
+  </data>
+  <data name="Cut.TooltipService.Tooltip" xml:space="preserve">
+    <value>Cut (Ctrl+C)</value>
+  </data>
+  <data name="Dark.Content" xml:space="preserve">
+    <value>Dark</value>
+  </data>
+  <data name="DefaultFont.Text" xml:space="preserve">
+    <value>Default Font</value>
+  </data>
+  <data name="DefaultFontColor.Text" xml:space="preserve">
+    <value>Default Font Color</value>
+  </data>
+  <data name="DefaultFontSize.Text" xml:space="preserve">
+    <value>Default Font Size</value>
+  </data>
+  <data name="DevelopedBy.Text" xml:space="preserve">
+    <value>Developed by Yair Aichenbaum</value>
+  </data>
+  <data name="GeneralAutoSave.Text" xml:space="preserve">
+    <value>Auto Save</value>
+  </data>
+  <data name="GeneralDefaultType.Text" xml:space="preserve">
+    <value>Default File Type</value>
+  </data>
+  <data name="GeneralLaunchMode.Text" xml:space="preserve">
+    <value>Launch Mode</value>
+  </data>
+  <data name="GeneralToggleSwitch.OffContent" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="GeneralToggleSwitch.OnContent" xml:space="preserve">
+    <value>On</value>
+  </data>
+  <data name="IconDesignBy.Text" xml:space="preserve">
+    <value>Icon design by James Arney</value>
+  </data>
+  <data name="Italic.Label" xml:space="preserve">
+    <value>Italic</value>
+  </data>
+  <data name="Italic.TooltipService.Tooltip" xml:space="preserve">
+    <value>Italic (Ctrl+I)</value>
+  </data>
+  <data name="Justify.Label" xml:space="preserve">
+    <value>Justify</value>
+  </data>
+  <data name="Justify.TooltipService.Tooltip" xml:space="preserve">
+    <value>Align justify (Ctrl+J)</value>
+  </data>
+  <data name="Left.Label" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="Left.TooltipService.Tooltip" xml:space="preserve">
+    <value>Align left (Ctrl+L)</value>
+  </data>
+  <data name="Light.Content" xml:space="preserve">
+    <value>Light</value>
+  </data>
+  <data name="Paste.Label" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="Paste.TooltipService.Tooltip" xml:space="preserve">
+    <value>Paste (Ctrl+P)</value>
+  </data>
+  <data name="RateAndReview.Content" xml:space="preserve">
+    <value>Rate and review</value>
+  </data>
+  <data name="Right.Label" xml:space="preserve">
+    <value>Right</value>
+  </data>
+  <data name="Right.TooltipService.Tooltip" xml:space="preserve">
+    <value>Align right (Ctrl+R)</value>
+  </data>
+  <data name="SaveDialog.Text" xml:space="preserve">
+    <value>Would you like to save your changes?</value>
+  </data>
+  <data name="SaveDialogCancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="SaveDialogNo.Content" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="SaveDialogYes.Content" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="SendFeedback.Content" xml:space="preserve">
+    <value>Send Feedback</value>
+  </data>
+  <data name="SettingsPivot.Title" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SettingsTab1.Header" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="SettingsTab2.Header" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="SettingsTab3.Header" xml:space="preserve">
+    <value>Font</value>
+  </data>
+  <data name="SettingsTab4.Header" xml:space="preserve">
+    <value>Toolbar</value>
+  </data>
+  <data name="SettingsTab5.Header" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="ShowAlignCenter.OffContent" xml:space="preserve">
+    <value>Hide align center</value>
+  </data>
+  <data name="ShowAlignCenter.OnContent" xml:space="preserve">
+    <value>Show align center</value>
+  </data>
+  <data name="ShowAlignJustify.OffContent" xml:space="preserve">
+    <value>Hide align justify</value>
+  </data>
+  <data name="ShowAlignJustify.OnContent" xml:space="preserve">
+    <value>Show align justify</value>
+  </data>
+  <data name="ShowAlignLeft.OffContent" xml:space="preserve">
+    <value>Hide align left</value>
+  </data>
+  <data name="ShowAlignLeft.OnContent" xml:space="preserve">
+    <value>Show align left</value>
+  </data>
+  <data name="ShowAlignRight.OffContent" xml:space="preserve">
+    <value>Hide align right</value>
+  </data>
+  <data name="ShowAlignRight.OnContent" xml:space="preserve">
+    <value>Show align right</value>
+  </data>
+  <data name="ShowBullets.OffContent" xml:space="preserve">
+    <value>Hide bullet list</value>
+  </data>
+  <data name="ShowBullets.OnContent" xml:space="preserve">
+    <value>Show bullet list</value>
+  </data>
+  <data name="ShowStrikethrough.OffContent" xml:space="preserve">
+    <value>Hide strikethrough option</value>
+  </data>
+  <data name="ShowStrikethrough.OnContent" xml:space="preserve">
+    <value>Show strikethrough option</value>
+  </data>
+  <data name="SizeDown.Label" xml:space="preserve">
+    <value>Size Down</value>
+  </data>
+  <data name="SizeDown.TooltipService.Tooltip" xml:space="preserve">
+    <value>Size Down</value>
+  </data>
+  <data name="SizeUp.Label" xml:space="preserve">
+    <value>Size Up</value>
+  </data>
+  <data name="SizeUp.TooltipService.Tooltip" xml:space="preserve">
+    <value>Size Up</value>
+  </data>
+  <data name="SpellCheck.Text" xml:space="preserve">
+    <value>Spell Check</value>
+  </data>
+  <data name="Strikethrough.Label" xml:space="preserve">
+    <value>Strikethrough</value>
+  </data>
+  <data name="Strikethrough.TooltipService.Tooltip" xml:space="preserve">
+    <value>Strikethrough</value>
+  </data>
+  <data name="SystemDefault.Content" xml:space="preserve">
+    <value>System Default</value>
+  </data>
+  <data name="TextColor.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Font Color</value>
+  </data>
+  <data name="Underline.Label" xml:space="preserve">
+    <value>Underline</value>
+  </data>
+  <data name="Underline.TooltipService.Tooltip" xml:space="preserve">
+    <value>Underline (Ctrl+U)</value>
+  </data>
+  <data name="WordWrap.Text" xml:space="preserve">
+    <value>Word Wrap</value>
+  </data>
+</root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -1,110 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -130,7 +25,7 @@
     <value>สัญลักษณ์หัวข้อ</value>
   </data>
   <data name="Center.Label" xml:space="preserve">
-    <value>กลาง</value>
+    <value>กึ่งกลาง</value>
   </data>
   <data name="CmdFocusMode" xml:space="preserve">
     <value>เปิดโหมดเน้นพิมพ์</value>
@@ -154,16 +49,16 @@
     <value>ตั้งค่า</value>
   </data>
   <data name="CmdShare.Label" xml:space="preserve">
-    <value>แบ่งปัน</value>
+    <value>แชร์</value>
   </data>
   <data name="CmdUndo.Label" xml:space="preserve">
     <value>เลิกทำ</value>
   </data>
   <data name="CompactOverlay.Content" xml:space="preserve">
-    <value>ทับแอพอื่น</value>
+    <value>ทับแอปอื่น</value>
   </data>
   <data name="Contribute.Content" xml:space="preserve">
-    <value>บริจาค ช่วยเหลือนักพัฒนา</value>
+    <value>บริจาคช่วยเหลือนักพัฒนา</value>
   </data>
   <data name="Copy.Label" xml:space="preserve">
     <value>คัดลอก</value>
@@ -172,7 +67,7 @@
     <value>ตัด</value>
   </data>
   <data name="Dark.Content" xml:space="preserve">
-    <value>สีเข้ม</value>
+    <value>มืด</value>
   </data>
   <data name="DefaultFont.Text" xml:space="preserve">
     <value>ฟอนต์เริ่มต้น</value>
@@ -202,7 +97,7 @@
     <value>เปิด</value>
   </data>
   <data name="IconDesignBy.Text" xml:space="preserve">
-    <value>ออกแบบไอคอนโดย by James Arney</value>
+    <value>ออกแบบไอคอนแอปโดย James Arney</value>
   </data>
   <data name="Italic.Label" xml:space="preserve">
     <value>ตัวเอียง</value>
@@ -220,22 +115,22 @@
     <value>วาง</value>
   </data>
   <data name="RateAndReview.Content" xml:space="preserve">
-    <value>ให้คะแนนและรีวิว</value>
+    <value>ให้คะแนนและวิจารณ์</value>
   </data>
   <data name="Right.Label" xml:space="preserve">
-    <value>ซ้าย</value>
+    <value>ขวา</value>
   </data>
   <data name="SaveDialog.Text" xml:space="preserve">
-    <value>คุณต้องการบันทึกการเปลี่ยนแปลงที่พิมพ์ไปไหม?</value>
+    <value>คุณต้องการบันทึกการเปลี่ยนแปลงของคุณหรือไม่</value>
   </data>
   <data name="SaveDialogCancel.Content" xml:space="preserve">
     <value>ยกเลิก</value>
   </data>
   <data name="SaveDialogNo.Content" xml:space="preserve">
-    <value>ไม่บันทึก</value>
+    <value>ไม่ใช่</value>
   </data>
   <data name="SaveDialogYes.Content" xml:space="preserve">
-    <value>บันทึก</value>
+    <value>ใช่</value>
   </data>
   <data name="SendFeedback.Content" xml:space="preserve">
     <value>ส่งคำติชม</value>
@@ -250,7 +145,7 @@
     <value>ธีม</value>
   </data>
   <data name="SettingsTab3.Header" xml:space="preserve">
-    <value>ฟอนต์</value>
+    <value>แบบอักษร</value>
   </data>
   <data name="SettingsTab4.Header" xml:space="preserve">
     <value>แถบเครื่องมือ</value>
@@ -304,10 +199,10 @@
     <value>เช็คคำผิด</value>
   </data>
   <data name="Strikethrough.Label" xml:space="preserve">
-    <value>ขีดฆ่า</value>
+    <value>ขีดทับ</value>
   </data>
   <data name="SystemDefault.Content" xml:space="preserve">
-    <value>ตามสีระบบ</value>
+    <value>ค่าเริ่มต้นระบบ</value>
   </data>
   <data name="Underline.Label" xml:space="preserve">
     <value>ขีดเส้นใต้</value>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -1,0 +1,384 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTheme.Text" xml:space="preserve">
+    <value>ธีมของแอป</value>
+  </data>
+  <data name="AutoSaveSwitch.Text" xml:space="preserve">
+    <value>บันทึกอัตโนมัติ</value>
+  </data>
+  <data name="Bold.Label" xml:space="preserve">
+    <value>ตัวหนา</value>
+  </data>
+  <data name="Bold.TooltipService.Tooltip" xml:space="preserve">
+    <value>ตัวหนา (Ctrl+B)</value>
+  </data>
+  <data name="BulletList.Label" xml:space="preserve">
+    <value>สัญลักษณ์หัวข้อ</value>
+  </data>
+  <data name="BulletList.TooltipService.Tooltip" xml:space="preserve">
+    <value>เปิดใช้สัญลักษณ์หัวข้อ</value>
+  </data>
+  <data name="Center.Label" xml:space="preserve">
+    <value>กลาง</value>
+  </data>
+  <data name="Center.TooltipService.Tooltip" xml:space="preserve">
+    <value>จัดกลาง (Ctrl+E)</value>
+  </data>
+  <data name="CmdFocusMode" xml:space="preserve">
+    <value>เปิดโหมดเน้นพิมพ์</value>
+  </data>
+  <data name="CmdNew.Label" xml:space="preserve">
+    <value>เริ่มใหม่</value>
+  </data>
+  <data name="CmdNew.TooltipService.Tooltip" xml:space="preserve">
+    <value>เริ่มใหม่</value>
+  </data>
+  <data name="CmdOpen.Label" xml:space="preserve">
+    <value>เปิด</value>
+  </data>
+  <data name="CmdOpen.TooltipService.Tooltip" xml:space="preserve">
+    <value>เปิด (Ctrl+O)</value>
+  </data>
+  <data name="CmdRedo.Label" xml:space="preserve">
+    <value>ทำซ้ำ</value>
+  </data>
+  <data name="CmdRedo.TooltipService.Tooltip" xml:space="preserve">
+    <value>ทำซ้ำ (Ctrl+Y)</value>
+  </data>
+  <data name="CmdReview" xml:space="preserve">
+    <value>รีวิว</value>
+  </data>
+  <data name="CmdSave.Label" xml:space="preserve">
+    <value>บันทึก</value>
+  </data>
+  <data name="CmdSave.TooltipService.Tooltip" xml:space="preserve">
+    <value>บันทึก (Ctrl+S)</value>
+  </data>
+  <data name="CmdSettings" xml:space="preserve">
+    <value>ตั้งค่า</value>
+  </data>
+  <data name="CmdSettings.ToolTipService.ToolTip" xml:space="preserve">
+    <value>ตั้งค่า</value>
+  </data>
+  <data name="CmdShare" xml:space="preserve">
+    <value>แบ่งปัน</value>
+  </data>
+  <data name="CmdShare.ToolTipService.ToolTip" xml:space="preserve">
+    <value>ส่งไฟล์นี้ให้เพื่อนของคุณ</value>
+  </data>
+  <data name="CmdUndo.Label" xml:space="preserve">
+    <value>เลิกทำ</value>
+  </data>
+  <data name="CmdUndo.TooltipService.Tooltip" xml:space="preserve">
+    <value>เลิกทำ (Ctrl+Z)</value>
+  </data>
+  <data name="CompactOverlay.Content" xml:space="preserve">
+    <value>ทับแอพอื่น</value>
+  </data>
+  <data name="Contribute.Content" xml:space="preserve">
+    <value>บริจาค ช่วยเหลือนักพัฒนา</value>
+  </data>
+  <data name="Copy.Label" xml:space="preserve">
+    <value>คัดลอก</value>
+  </data>
+  <data name="Copy.TooltipService.Tooltip" xml:space="preserve">
+    <value>คัดลอก (Ctrl+C)</value>
+  </data>
+  <data name="Cut.Label" xml:space="preserve">
+    <value>ตัด</value>
+  </data>
+  <data name="Cut.TooltipService.Tooltip" xml:space="preserve">
+    <value>ตัด (Ctrl+C)</value>
+  </data>
+  <data name="Dark.Content" xml:space="preserve">
+    <value>สีเข้ม</value>
+  </data>
+  <data name="DefaultFont.Text" xml:space="preserve">
+    <value>ฟอนต์เริ่มต้น</value>
+  </data>
+  <data name="DefaultFontColor.Text" xml:space="preserve">
+    <value>สีฟอนต์เริ่มต้น</value>
+  </data>
+  <data name="DefaultFontSize.Text" xml:space="preserve">
+    <value>ขนาดฟอนต์เริ่มต้น</value>
+  </data>
+  <data name="DevelopedBy.Text" xml:space="preserve">
+    <value>สร้างและพัฒนาโดย Yair Aichenbaum</value>
+  </data>
+  <data name="GeneralAutoSave.Text" xml:space="preserve">
+    <value>บันทึกอัตโนมัติ</value>
+  </data>
+  <data name="GeneralDefaultType.Text" xml:space="preserve">
+    <value>ชนิดไฟล์เริ่มต้น</value>
+  </data>
+  <data name="GeneralLaunchMode.Text" xml:space="preserve">
+    <value>เริ่มแอปในโหมด</value>
+  </data>
+  <data name="GeneralToggleSwitch.OffContent" xml:space="preserve">
+    <value>ปิด</value>
+  </data>
+  <data name="GeneralToggleSwitch.OnContent" xml:space="preserve">
+    <value>เปิด</value>
+  </data>
+  <data name="IconDesignBy.Text" xml:space="preserve">
+    <value>ออกแบบไอคอนโดย by James Arney</value>
+  </data>
+  <data name="Italic.Label" xml:space="preserve">
+    <value>ตัวเอียง</value>
+  </data>
+  <data name="Italic.TooltipService.Tooltip" xml:space="preserve">
+    <value>ตัวเอียง (Ctrl+I)</value>
+  </data>
+  <data name="Justify.Label" xml:space="preserve">
+    <value>เต็มแนว</value>
+  </data>
+  <data name="Justify.TooltipService.Tooltip" xml:space="preserve">
+    <value>จัดเต็มแนว (Ctrl+J)</value>
+  </data>
+  <data name="Left.Label" xml:space="preserve">
+    <value>ซ้าย</value>
+  </data>
+  <data name="Left.TooltipService.Tooltip" xml:space="preserve">
+    <value>จัดชิดซ้าย (Ctrl+L)</value>
+  </data>
+  <data name="Light.Content" xml:space="preserve">
+    <value>สีสว่าง</value>
+  </data>
+  <data name="Paste.Label" xml:space="preserve">
+    <value>วาง</value>
+  </data>
+  <data name="Paste.TooltipService.Tooltip" xml:space="preserve">
+    <value>วาง (Ctrl+P)</value>
+  </data>
+  <data name="RateAndReview.Content" xml:space="preserve">
+    <value>ให้คะแนนและรีวิว</value>
+  </data>
+  <data name="Right.Label" xml:space="preserve">
+    <value>ซ้าย</value>
+  </data>
+  <data name="Right.TooltipService.Tooltip" xml:space="preserve">
+    <value>จัดชิดซ้าย (Ctrl+R)</value>
+  </data>
+  <data name="SaveDialog.Text" xml:space="preserve">
+    <value>คุณต้องการบันทึกการเปลี่ยนแปลงที่พิมพ์ไปไหม?</value>
+  </data>
+  <data name="SaveDialogCancel.Content" xml:space="preserve">
+    <value>ยกเลิก</value>
+  </data>
+  <data name="SaveDialogNo.Content" xml:space="preserve">
+    <value>ไม่บันทึก</value>
+  </data>
+  <data name="SaveDialogYes.Content" xml:space="preserve">
+    <value>บันทึก</value>
+  </data>
+  <data name="SendFeedback.Content" xml:space="preserve">
+    <value>ส่งคำติชม</value>
+  </data>
+  <data name="SettingsPivot.Title" xml:space="preserve">
+    <value>การตั้งค่า</value>
+  </data>
+  <data name="SettingsTab1.Header" xml:space="preserve">
+    <value>ทั่วไป</value>
+  </data>
+  <data name="SettingsTab2.Header" xml:space="preserve">
+    <value>ธีม</value>
+  </data>
+  <data name="SettingsTab3.Header" xml:space="preserve">
+    <value>ฟอนต์</value>
+  </data>
+  <data name="SettingsTab4.Header" xml:space="preserve">
+    <value>แถบเครื่องมือ</value>
+  </data>
+  <data name="SettingsTab5.Header" xml:space="preserve">
+    <value>เกี่ยวกับ</value>
+  </data>
+  <data name="ShowAlignCenter.OffContent" xml:space="preserve">
+    <value>ซ่อนปุ่มจัดกลาง</value>
+  </data>
+  <data name="ShowAlignCenter.OnContent" xml:space="preserve">
+    <value>แสดงปุ่มจัดกลาง</value>
+  </data>
+  <data name="ShowAlignJustify.OffContent" xml:space="preserve">
+    <value>ซ่อนปุ่มจัดเต็มแนว</value>
+  </data>
+  <data name="ShowAlignJustify.OnContent" xml:space="preserve">
+    <value>แสดงปุ่มจัดเต็มแนว</value>
+  </data>
+  <data name="ShowAlignLeft.OffContent" xml:space="preserve">
+    <value>ซ่อนปุ่มจัดชิดซ้าย</value>
+  </data>
+  <data name="ShowAlignLeft.OnContent" xml:space="preserve">
+    <value>แสดงปุ่มจัดชิดซ้าย</value>
+  </data>
+  <data name="ShowAlignRight.OffContent" xml:space="preserve">
+    <value>ซ่อนปุ่มจัดชิดขวา</value>
+  </data>
+  <data name="ShowAlignRight.OnContent" xml:space="preserve">
+    <value>แสดงปุ่มจัดชิดขวา</value>
+  </data>
+  <data name="ShowBullets.OffContent" xml:space="preserve">
+    <value>ซ่อนปุ่มสัญลักษณ์หัวข้อ</value>
+  </data>
+  <data name="ShowBullets.OnContent" xml:space="preserve">
+    <value>แสดงปุ่มสัญลักษณ์หัวข้อ</value>
+  </data>
+  <data name="ShowStrikethrough.OffContent" xml:space="preserve">
+    <value>ซ่อนปุ่มขีดทับ</value>
+  </data>
+  <data name="ShowStrikethrough.OnContent" xml:space="preserve">
+    <value>แสดงปุ่มขีดทับ</value>
+  </data>
+  <data name="SizeDown.Label" xml:space="preserve">
+    <value>ย่อขนาด</value>
+  </data>
+  <data name="SizeDown.TooltipService.Tooltip" xml:space="preserve">
+    <value>ย่อขนาด</value>
+  </data>
+  <data name="SizeUp.Label" xml:space="preserve">
+    <value>ขยายขนาด</value>
+  </data>
+  <data name="SizeUp.TooltipService.Tooltip" xml:space="preserve">
+    <value>ขยายขนาด</value>
+  </data>
+  <data name="SpellCheck.Text" xml:space="preserve">
+    <value>เช็คคำผิด</value>
+  </data>
+  <data name="Strikethrough.Label" xml:space="preserve">
+    <value>ขีดฆ่า</value>
+  </data>
+  <data name="Strikethrough.TooltipService.Tooltip" xml:space="preserve">
+    <value>ขีดฆ่า</value>
+  </data>
+  <data name="SystemDefault.Content" xml:space="preserve">
+    <value>ตามสีระบบ</value>
+  </data>
+  <data name="TextColor.ToolTipService.ToolTip" xml:space="preserve">
+    <value>สีฟอนต์</value>
+  </data>
+  <data name="Underline.Label" xml:space="preserve">
+    <value>ขีดเส้นใต้</value>
+  </data>
+  <data name="Underline.TooltipService.Tooltip" xml:space="preserve">
+    <value>ขีดเส้นใต้ (Ctrl+U)</value>
+  </data>
+  <data name="WordWrap.Text" xml:space="preserve">
+    <value>ตัดคำ</value>
+  </data>
+</root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -22,13 +22,10 @@
     <value>ตัวหนา</value>
   </data>
   <data name="BulletList.Label" xml:space="preserve">
-    <value>สัญลักษณ์หัวข้อ</value>
+    <value>สัญลักษณ์หัวข้อย่อย</value>
   </data>
   <data name="Center.Label" xml:space="preserve">
     <value>กึ่งกลาง</value>
-  </data>
-  <data name="CmdFocusMode" xml:space="preserve">
-    <value>เปิดโหมดเน้นพิมพ์</value>
   </data>
   <data name="CmdNew.Label" xml:space="preserve">
     <value>เริ่มใหม่</value>
@@ -85,7 +82,7 @@
     <value>บันทึกอัตโนมัติ</value>
   </data>
   <data name="GeneralDefaultType.Text" xml:space="preserve">
-    <value>ชนิดไฟล์เริ่มต้น</value>
+    <value>ฃนิดไฟล์เริ่มต้น</value>
   </data>
   <data name="GeneralLaunchMode.Text" xml:space="preserve">
     <value>เริ่มแอปในโหมด</value>
@@ -209,5 +206,8 @@
   </data>
   <data name="WordWrap.Text" xml:space="preserve">
     <value>ตัดคำ</value>
+  </data>
+  <data name="CmdFocusMode.Label" xml:space="preserve">
+    <value>เปิดโหมดเน้นพิมพ์</value>
   </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -363,4 +363,7 @@
   <data name="UnderlineTooltip.Text" xml:space="preserve">
     <value>ขีดเส้นใต้ (Ctrl+U)</value>
   </data>
+  <data name="JustifyTooltip.Text" xml:space="preserve">
+    <value>จัดกลาง (Ctrl+J)</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -240,4 +240,61 @@
   <data name="VersionFormat" xml:space="preserve">
     <value>เวอร์ชั่น: {0}.{1}.{2}.{3}</value>
   </data>
+  <data name="FontColorBlack.Content" xml:space="preserve">
+    <value>ดำ</value>
+  </data>
+  <data name="FontColorLightGreen.Content" xml:space="preserve">
+    <value>เขียว</value>
+  </data>
+  <data name="FontColorLightPink.Content" xml:space="preserve">
+    <value>ชมพู</value>
+  </data>
+  <data name="FontColorLightSalmon.Content" xml:space="preserve">
+    <value>ส้ม</value>
+  </data>
+  <data name="FontColorLightYellow.Content" xml:space="preserve">
+    <value>เหลือง</value>
+  </data>
+  <data name="FontColorSkyBlue.Content" xml:space="preserve">
+    <value>ฟ้า</value>
+  </data>
+  <data name="FontColorWhite.Content" xml:space="preserve">
+    <value>ขาว</value>
+  </data>
+  <data name="LaunchModeDefault.Content" xml:space="preserve">
+    <value>ปกติ</value>
+  </data>
+  <data name="LaunchModeFocus.Content" xml:space="preserve">
+    <value>เน้นพิมพ์</value>
+  </data>
+  <data name="LaunchModeOnTop.Content" xml:space="preserve">
+    <value>ทับแอปอื่น</value>
+  </data>
+  <data name="TextColorBlack.Text" xml:space="preserve">
+    <value>ดำ</value>
+  </data>
+  <data name="TextColorBlue.Text" xml:space="preserve">
+    <value>ฟ้า</value>
+  </data>
+  <data name="TextColorGreen.Text" xml:space="preserve">
+    <value>เขียว</value>
+  </data>
+  <data name="TextColorOrange.Text" xml:space="preserve">
+    <value>ส้ม</value>
+  </data>
+  <data name="TextColorPink.Text" xml:space="preserve">
+    <value>ชมพู</value>
+  </data>
+  <data name="TextColorWhite.Text" xml:space="preserve">
+    <value>ขาว</value>
+  </data>
+  <data name="TextColorYellow.Text" xml:space="preserve">
+    <value>เหลือง</value>
+  </data>
+  <data name="DefaultFontColorCombobox.PlaceholderText" xml:space="preserve">
+    <value>ดำ</value>
+  </data>
+  <data name="GeneralLaunchModeCombobox.PlaceholderText" xml:space="preserve">
+    <value>ปกติ</value>
+  </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -106,7 +106,7 @@
     <value>ซ้าย</value>
   </data>
   <data name="Light.Content" xml:space="preserve">
-    <value>สีสว่าง</value>
+    <value>สว่าง</value>
   </data>
   <data name="Paste.Label" xml:space="preserve">
     <value>วาง</value>
@@ -209,5 +209,35 @@
   </data>
   <data name="CmdFocusMode.Label" xml:space="preserve">
     <value>เปิดโหมดเน้นพิมพ์</value>
+  </data>
+  <data name="ErrorDialogContent" xml:space="preserve">
+    <value>ไม่สามารถเปิดไฟล์นี้ได้</value>
+  </data>
+  <data name="ErrorDialogOk" xml:space="preserve">
+    <value>ตกลง</value>
+  </data>
+  <data name="ErrorDialogTitle" xml:space="preserve">
+    <value>เกิดข้อผิดพลาด</value>
+  </data>
+  <data name="NewDocument" xml:space="preserve">
+    <value>เอกสารใหม่</value>
+  </data>
+  <data name="NewUserFeedbackContent" xml:space="preserve">
+    <value>กรุณาส่งข้อคิดเห็นหรือคำวิจารณ์ให้กับแอปของเราใน Store</value>
+  </data>
+  <data name="NewUserFeedbackNo" xml:space="preserve">
+    <value>ปิด</value>
+  </data>
+  <data name="NewUserFeedbackTitle" xml:space="preserve">
+    <value>คุณรู้สึกยังไงบ้างกับแอป Quick Pad?</value>
+  </data>
+  <data name="NewUserFeedbackYes" xml:space="preserve">
+    <value>ตกลง</value>
+  </data>
+  <data name="NothingToShare" xml:space="preserve">
+    <value>ไม่มีอะไรจะแชร์ กรุณาพิมพ์อะไรสักอย่างเพื่อจะแชร์</value>
+  </data>
+  <data name="VersionFormat" xml:space="preserve">
+    <value>เวอร์ชั่น: {0}.{1}.{2}.{3}</value>
   </data>
 </root>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -126,20 +126,11 @@
   <data name="Bold.Label" xml:space="preserve">
     <value>ตัวหนา</value>
   </data>
-  <data name="Bold.TooltipService.Tooltip" xml:space="preserve">
-    <value>ตัวหนา (Ctrl+B)</value>
-  </data>
   <data name="BulletList.Label" xml:space="preserve">
     <value>สัญลักษณ์หัวข้อ</value>
   </data>
-  <data name="BulletList.TooltipService.Tooltip" xml:space="preserve">
-    <value>เปิดใช้สัญลักษณ์หัวข้อ</value>
-  </data>
   <data name="Center.Label" xml:space="preserve">
     <value>กลาง</value>
-  </data>
-  <data name="Center.TooltipService.Tooltip" xml:space="preserve">
-    <value>จัดกลาง (Ctrl+E)</value>
   </data>
   <data name="CmdFocusMode" xml:space="preserve">
     <value>เปิดโหมดเน้นพิมพ์</value>
@@ -147,47 +138,26 @@
   <data name="CmdNew.Label" xml:space="preserve">
     <value>เริ่มใหม่</value>
   </data>
-  <data name="CmdNew.TooltipService.Tooltip" xml:space="preserve">
-    <value>เริ่มใหม่</value>
-  </data>
   <data name="CmdOpen.Label" xml:space="preserve">
     <value>เปิด</value>
-  </data>
-  <data name="CmdOpen.TooltipService.Tooltip" xml:space="preserve">
-    <value>เปิด (Ctrl+O)</value>
   </data>
   <data name="CmdRedo.Label" xml:space="preserve">
     <value>ทำซ้ำ</value>
   </data>
-  <data name="CmdRedo.TooltipService.Tooltip" xml:space="preserve">
-    <value>ทำซ้ำ (Ctrl+Y)</value>
-  </data>
-  <data name="CmdReview" xml:space="preserve">
+  <data name="CmdReview.Label" xml:space="preserve">
     <value>รีวิว</value>
   </data>
   <data name="CmdSave.Label" xml:space="preserve">
     <value>บันทึก</value>
   </data>
-  <data name="CmdSave.TooltipService.Tooltip" xml:space="preserve">
-    <value>บันทึก (Ctrl+S)</value>
-  </data>
-  <data name="CmdSettings" xml:space="preserve">
+  <data name="CmdSettings.Label" xml:space="preserve">
     <value>ตั้งค่า</value>
   </data>
-  <data name="CmdSettings.ToolTipService.ToolTip" xml:space="preserve">
-    <value>ตั้งค่า</value>
-  </data>
-  <data name="CmdShare" xml:space="preserve">
+  <data name="CmdShare.Label" xml:space="preserve">
     <value>แบ่งปัน</value>
-  </data>
-  <data name="CmdShare.ToolTipService.ToolTip" xml:space="preserve">
-    <value>ส่งไฟล์นี้ให้เพื่อนของคุณ</value>
   </data>
   <data name="CmdUndo.Label" xml:space="preserve">
     <value>เลิกทำ</value>
-  </data>
-  <data name="CmdUndo.TooltipService.Tooltip" xml:space="preserve">
-    <value>เลิกทำ (Ctrl+Z)</value>
   </data>
   <data name="CompactOverlay.Content" xml:space="preserve">
     <value>ทับแอพอื่น</value>
@@ -198,14 +168,8 @@
   <data name="Copy.Label" xml:space="preserve">
     <value>คัดลอก</value>
   </data>
-  <data name="Copy.TooltipService.Tooltip" xml:space="preserve">
-    <value>คัดลอก (Ctrl+C)</value>
-  </data>
   <data name="Cut.Label" xml:space="preserve">
     <value>ตัด</value>
-  </data>
-  <data name="Cut.TooltipService.Tooltip" xml:space="preserve">
-    <value>ตัด (Ctrl+C)</value>
   </data>
   <data name="Dark.Content" xml:space="preserve">
     <value>สีเข้ม</value>
@@ -243,20 +207,11 @@
   <data name="Italic.Label" xml:space="preserve">
     <value>ตัวเอียง</value>
   </data>
-  <data name="Italic.TooltipService.Tooltip" xml:space="preserve">
-    <value>ตัวเอียง (Ctrl+I)</value>
-  </data>
   <data name="Justify.Label" xml:space="preserve">
     <value>เต็มแนว</value>
   </data>
-  <data name="Justify.TooltipService.Tooltip" xml:space="preserve">
-    <value>จัดเต็มแนว (Ctrl+J)</value>
-  </data>
   <data name="Left.Label" xml:space="preserve">
     <value>ซ้าย</value>
-  </data>
-  <data name="Left.TooltipService.Tooltip" xml:space="preserve">
-    <value>จัดชิดซ้าย (Ctrl+L)</value>
   </data>
   <data name="Light.Content" xml:space="preserve">
     <value>สีสว่าง</value>
@@ -264,17 +219,11 @@
   <data name="Paste.Label" xml:space="preserve">
     <value>วาง</value>
   </data>
-  <data name="Paste.TooltipService.Tooltip" xml:space="preserve">
-    <value>วาง (Ctrl+P)</value>
-  </data>
   <data name="RateAndReview.Content" xml:space="preserve">
     <value>ให้คะแนนและรีวิว</value>
   </data>
   <data name="Right.Label" xml:space="preserve">
     <value>ซ้าย</value>
-  </data>
-  <data name="Right.TooltipService.Tooltip" xml:space="preserve">
-    <value>จัดชิดซ้าย (Ctrl+R)</value>
   </data>
   <data name="SaveDialog.Text" xml:space="preserve">
     <value>คุณต้องการบันทึกการเปลี่ยนแปลงที่พิมพ์ไปไหม?</value>
@@ -348,13 +297,7 @@
   <data name="SizeDown.Label" xml:space="preserve">
     <value>ย่อขนาด</value>
   </data>
-  <data name="SizeDown.TooltipService.Tooltip" xml:space="preserve">
-    <value>ย่อขนาด</value>
-  </data>
   <data name="SizeUp.Label" xml:space="preserve">
-    <value>ขยายขนาด</value>
-  </data>
-  <data name="SizeUp.TooltipService.Tooltip" xml:space="preserve">
     <value>ขยายขนาด</value>
   </data>
   <data name="SpellCheck.Text" xml:space="preserve">
@@ -363,20 +306,11 @@
   <data name="Strikethrough.Label" xml:space="preserve">
     <value>ขีดฆ่า</value>
   </data>
-  <data name="Strikethrough.TooltipService.Tooltip" xml:space="preserve">
-    <value>ขีดฆ่า</value>
-  </data>
   <data name="SystemDefault.Content" xml:space="preserve">
     <value>ตามสีระบบ</value>
   </data>
-  <data name="TextColor.ToolTipService.ToolTip" xml:space="preserve">
-    <value>สีฟอนต์</value>
-  </data>
   <data name="Underline.Label" xml:space="preserve">
     <value>ขีดเส้นใต้</value>
-  </data>
-  <data name="Underline.TooltipService.Tooltip" xml:space="preserve">
-    <value>ขีดเส้นใต้ (Ctrl+U)</value>
   </data>
   <data name="WordWrap.Text" xml:space="preserve">
     <value>ตัดคำ</value>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -70,7 +70,7 @@
     <value>ฟอนต์เริ่มต้น</value>
   </data>
   <data name="DefaultFontColor.Text" xml:space="preserve">
-    <value>สีฟอนต์เริ่มต้น</value>
+    <value>สีตัวอักษรเริ่มต้น</value>
   </data>
   <data name="DefaultFontSize.Text" xml:space="preserve">
     <value>ขนาดฟอนต์เริ่มต้น</value>
@@ -296,5 +296,71 @@
   </data>
   <data name="GeneralLaunchModeCombobox.PlaceholderText" xml:space="preserve">
     <value>ปกติ</value>
+  </data>
+  <data name="BoldTooltip.Text" xml:space="preserve">
+    <value>ตัวหนา (Ctrl+B)</value>
+  </data>
+  <data name="BulletListTooltip.Text" xml:space="preserve">
+    <value>เปิดใช้สัญลักษณ์หัวข้อ</value>
+  </data>
+  <data name="CenterTooltip.Text" xml:space="preserve">
+    <value>จัดกลาง (Ctrl+E)</value>
+  </data>
+  <data name="CmdNewTooltip.Text" xml:space="preserve">
+    <value>เริ่มใหม่</value>
+  </data>
+  <data name="CmdOpenTooltip.Text" xml:space="preserve">
+    <value>เปิด (Ctrl+O)</value>
+  </data>
+  <data name="CmdRedoTooltip.Text" xml:space="preserve">
+    <value>ทำซ้ำ (Ctrl+Y)</value>
+  </data>
+  <data name="CmdSaveTooltip.Text" xml:space="preserve">
+    <value>บันทึก (Ctrl+S)</value>
+  </data>
+  <data name="CmdSettingsTooltip.Text" xml:space="preserve">
+    <value>ตั้งค่า</value>
+  </data>
+  <data name="CmdShareTooltip.Text" xml:space="preserve">
+    <value>ส่งไฟล์นี้ให้เพื่อนของคุณ</value>
+  </data>
+  <data name="CmdUndoTooltip.Text" xml:space="preserve">
+    <value>เลิกทำ (Ctrl+Z)</value>
+  </data>
+  <data name="CopyTooltip.Text" xml:space="preserve">
+    <value>คัดลอก (Ctrl+C)</value>
+  </data>
+  <data name="CutTooltip.Text" xml:space="preserve">
+    <value>ตัด (Ctrl+X)</value>
+  </data>
+  <data name="ExitFocusMode.Text" xml:space="preserve">
+    <value>ออกจากโหมดเน้นพิมพ์</value>
+  </data>
+  <data name="ItalicTooltip.Text" xml:space="preserve">
+    <value>ตัวเอียง (Ctrl+I)</value>
+  </data>
+  <data name="LeftTooltip.Text" xml:space="preserve">
+    <value>จัดชิดซ้าย (Ctrl+L)</value>
+  </data>
+  <data name="PasteTooltip.Text" xml:space="preserve">
+    <value>วาง (Ctrl+V)</value>
+  </data>
+  <data name="RightTooltip.Text" xml:space="preserve">
+    <value>จัดชิดขวา (Ctrl+R)</value>
+  </data>
+  <data name="SizeDownTooltip.Text" xml:space="preserve">
+    <value>ย่อขนาด</value>
+  </data>
+  <data name="SizeUpTooltip.Text" xml:space="preserve">
+    <value>ขยายขนาด</value>
+  </data>
+  <data name="StrikethroughTooltip.Text" xml:space="preserve">
+    <value>ขีดทับ</value>
+  </data>
+  <data name="TextColorTooltip.Text" xml:space="preserve">
+    <value>สีตัวอักษร</value>
+  </data>
+  <data name="UnderlineTooltip.Text" xml:space="preserve">
+    <value>ขีดเส้นใต้ (Ctrl+U)</value>
   </data>
 </root>


### PR DESCRIPTION
I have complete the translate of the app.

The combo box has been change to Combo box item instead of string to be able to translate

And all tool tip has been move into text block.

If you want to add other translation language you need to have "Multilingual App Toolkit (2017+)" from the Visual Studio extension gallery. After install, right click the solution > Multilingual App Toolkit > Add translation language

This pull request also include Thai translation because it is the only language I know other than English.