### PR TITLE
Incorporate the x:Bind into app setting

### DIFF
--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -7,6 +7,7 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     xmlns:q="using:QuickPad"
+    xmlns:qfe="using:Quick_Pad_Free_Edition"
     RequestedTheme="{x:Bind QSetting.Theme, Mode=OneWay}"
     mc:Ignorable="d">
 
@@ -183,7 +184,7 @@
             </AppBarButton>
         </CommandBar>
 
-        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18" TextWrapping="{x:Bind q:Converter.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
+        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" TextWrapping="{x:Bind q:Converter.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}" FontSize="{x:Bind QSetting.DefaultFontSize, Mode=OneWay}"/>
 
         <ContentDialog x:Name="SaveDialog" Windows10version1809:CornerRadius="4" Background="{ThemeResource SystemControlAcrylicElementBrush}" BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}">
 
@@ -245,35 +246,39 @@
                         <PivotItem Header="Font" x:Name="SettingsTab3" x:Uid="SettingsTab3">
                             <Grid Height="200">
                                 <TextBlock x:Uid="DefaultFont" Text="Default Font" Margin="0,5,0,0" TextWrapping="Wrap"/>
-                                <ComboBox Margin="0,30,0,0" SelectedItem="{x:Bind QSetting.DefaultFont, Mode=TwoWay}" ItemsSource="{x:Bind AllFonts, Mode=OneWay}" Windows10version1809:CornerRadius="2" SelectionChanged="DefaultFont_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Segoe UI" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1"/>
+                                <ComboBox Margin="0,30,0,0" SelectedItem="{x:Bind QSetting.DefaultFont, Mode=TwoWay}" ItemsSource="{x:Bind AllFonts, Mode=OneWay}" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Segoe UI" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1"/>
                                 <TextBlock x:Uid="DefaultFontSize" Text="Default Font Size" Margin="0,70,0,0" TextWrapping="Wrap"/>
-                                <ComboBox Margin="0,95,0,0" Windows10version1809:CornerRadius="2" x:Name="DefaultFontSize" SelectionChanged="DefaultFontSize_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" Width="69" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
-                                    <x:String>4</x:String>
-                                    <x:String>6</x:String>
-                                    <x:String>8</x:String>
-                                    <x:String>10</x:String>
-                                    <x:String>12</x:String>
-                                    <x:String>14</x:String>
-                                    <x:String>16</x:String>
-                                    <x:String>18</x:String>
-                                    <x:String>20</x:String>
-                                    <x:String>22</x:String>
-                                    <x:String>24</x:String>
-                                    <x:String>26</x:String>
-                                    <x:String>28</x:String>
-                                    <x:String>36</x:String>
-                                    <x:String>48</x:String>
-                                    <x:String>72</x:String>
+                                <ComboBox SelectedItem="{x:Bind QSetting.DefaultFontSize, Mode=TwoWay}" Margin="0,95,0,0" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" Width="69" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
+                                    <x:Int32>4</x:Int32>
+                                    <x:Int32>6</x:Int32>
+                                    <x:Int32>8</x:Int32>
+                                    <x:Int32>10</x:Int32>
+                                    <x:Int32>12</x:Int32>
+                                    <x:Int32>14</x:Int32>
+                                    <x:Int32>16</x:Int32>
+                                    <x:Int32>18</x:Int32>
+                                    <x:Int32>20</x:Int32>
+                                    <x:Int32>22</x:Int32>
+                                    <x:Int32>24</x:Int32>
+                                    <x:Int32>26</x:Int32>
+                                    <x:Int32>28</x:Int32>
+                                    <x:Int32>36</x:Int32>
+                                    <x:Int32>48</x:Int32>
+                                    <x:Int32>72</x:Int32>
                                 </ComboBox>
                                 <TextBlock x:Uid="DefaultFontColor" Text="Default Font Color" Margin="0,135,0,0" TextWrapping="Wrap"/>
-                                <ComboBox Margin="0,160,0,0" x:Name="DefaultFontColor" x:Uid="DefaultFontColorCombobox" SelectionChanged="DefaultFontColor_SelectionChanged" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Black" Width="139" BorderThickness="1,1,1,1">
-                                    <ComboBoxItem Content="Black" Tag="Black" x:Uid="FontColorBlack" x:Name="FontColorBlack"/>
-                                    <ComboBoxItem Content="White" Tag="White" x:Uid="FontColorWhite" x:Name="FontColorWhite"/>
-                                    <ComboBoxItem Content="SkyBlue" Tag="SkyBlue" x:Uid="FontColorSkyBlue" x:Name="FontColorSkyBlue"/>
-                                    <ComboBoxItem Content="LightGreen" Tag="LightGreen" x:Uid="FontColorLightGreen" x:Name="FontColorLightGreen"/>
-                                    <ComboBoxItem Content="LightPink" Tag="LightPink" x:Uid="FontColorLightPink" x:Name="FontColorLightPink"/>
-                                    <ComboBoxItem Content="LightYellow" Tag="LightYellow" x:Uid="FontColorLightYellow" x:Name="FontColorLightYellow"/>
-                                    <ComboBoxItem Content="LightSalmon" Tag="LightSalmon" x:Uid="FontColorLightSalmon" x:Name="FontColorLightSalmon"/>
+                                <ComboBox Margin="0,160,0,0" x:Name="DefaultFontColor" x:Uid="DefaultFontColorCombobox" ItemsSource="{x:Bind FontColorCollections}" SelectedIndex="{x:Bind SelectedDefaultFontColor, Mode=TwoWay}" Windows10version1809:CornerRadius="2" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Black" Width="139" BorderThickness="1,1,1,1">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate x:DataType="qfe:FontColorItem">
+                                            <StackPanel Orientation="Horizontal">
+                                                <!--Default font color-->
+                                                <Rectangle Width="14" Height="14" Fill="{ThemeResource ApplicationForegroundThemeBrush}" Visibility="{x:Bind q:Converter.IfStringMatchShow(TechnicalName, 'Default'), Mode=OneWay}" />
+                                                <!--Other font color-->
+                                                <Rectangle Width="14" Height="14" Fill="{x:Bind q:Converter.FromColorToBrush(ActualColor)}" Visibility="{x:Bind q:Converter.IfStringMatchHide(TechnicalName, 'Default'), Mode=OneWay}" />
+                                                <TextBlock Text="{x:Bind ColorName}" Margin="5,0"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
                                 </ComboBox>
                             </Grid>
                         </PivotItem>
@@ -332,13 +337,13 @@
                 </ToolTipService.ToolTip>
                 <AppBarButton.Flyout>
                     <MenuFlyout>
-                        <MenuFlyoutItem x:Name="Black" x:Uid="TextColorBlack" Text="Black" Click="Black_Click" />
-                        <MenuFlyoutItem x:Name="White" x:Uid="TextColorWhite" Text="White" Click="White_Click" />
-                        <MenuFlyoutItem x:Name="Yellow" x:Uid="TextColorYellow" Text="Yellow" Click="Yellow_Click" />
-                        <MenuFlyoutItem x:Name="Blue" x:Uid="TextColorBlue" Text="Blue" Click="Blue_Click" />
-                        <MenuFlyoutItem x:Name="Pink" x:Uid="TextColorPink" Text="Pink" Click="Pink_Click" />
-                        <MenuFlyoutItem x:Name="Orange" x:Uid="TextColorOrange" Text="Orange" Click="Orange_Click" />
-                        <MenuFlyoutItem x:Name="Green" x:Uid="TextColorGreen" Text="Green" Click="Green_Click" />
+                        <MenuFlyoutItem x:Name="Black" x:Uid="TextColorBlack" Tag="Black" Text="Black" Click="SetFormatColor" />
+                        <MenuFlyoutItem x:Name="White" x:Uid="TextColorWhite" Tag="White" Text="White" Click="SetFormatColor" />
+                        <MenuFlyoutItem x:Name="Yellow" x:Uid="TextColorYellow" Tag="LightYellow" Text="Yellow" Click="SetFormatColor" />
+                        <MenuFlyoutItem x:Name="Blue" x:Uid="TextColorBlue" Tag="SkyBlue" Text="Blue" Click="SetFormatColor" />
+                        <MenuFlyoutItem x:Name="Pink" x:Uid="TextColorPink" Tag="LightPink" Text="Pink" Click="SetFormatColor" />
+                        <MenuFlyoutItem x:Name="Orange" x:Uid="TextColorOrange" Tag="LightSalmon" Text="Orange" Click="SetFormatColor" />
+                        <MenuFlyoutItem x:Name="Green" x:Uid="TextColorGreen" Tag="LightGreen" Text="Green" Click="SetFormatColor" />
                     </MenuFlyout>
                 </AppBarButton.Flyout>
             </AppBarButton>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -244,7 +244,7 @@
                         <PivotItem Header="Font" x:Name="SettingsTab3" x:Uid="SettingsTab3">
                             <Grid Height="200">
                                 <TextBlock x:Uid="DefaultFont" Text="Default Font" Margin="0,5,0,0" TextWrapping="Wrap"/>
-                                <ComboBox Margin="0,30,0,0" Windows10version1809:CornerRadius="2" SelectionChanged="DefaultFont_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" x:Name="DefaultFont" PlaceholderText="Segoe UI" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1"/>
+                                <ComboBox Margin="0,30,0,0" SelectedItem="{x:Bind QSetting.DefaultFont, Mode=TwoWay}" ItemsSource="{x:Bind AllFonts, Mode=OneWay}" Windows10version1809:CornerRadius="2" SelectionChanged="DefaultFont_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="Segoe UI" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1"/>
                                 <TextBlock x:Uid="DefaultFontSize" Text="Default Font Size" Margin="0,70,0,0" TextWrapping="Wrap"/>
                                 <ComboBox Margin="0,95,0,0" Windows10version1809:CornerRadius="2" x:Name="DefaultFontSize" SelectionChanged="DefaultFontSize_SelectionChanged" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" PlaceholderText="18" Width="69" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                     <x:String>4</x:String>
@@ -322,7 +322,7 @@
                     <Frame x:Name="FontBoxFrame" Width="167" Height="37" PointerMoved="FontSelected_PointerMoved" PointerExited="FontSelected_PointerExited" PointerPressed="Frame_PointerPressed"  Canvas.Left="1" Canvas.Top="1"  Canvas.ZIndex="100" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}"/>
                     <TextBlock x:Name="FontSelected" PointerMoved="FontSelected_PointerMoved" PointerExited="FontSelected_PointerExited" PointerPressed="Frame_PointerPressed" Text="Segoe UI" Canvas.Left="10" Canvas.Top="11" Canvas.ZIndex="100"/>
                     <TextBlock PointerMoved="FontSelected_PointerMoved" PointerExited="FontSelected_PointerExited" PointerPressed="Frame_PointerPressed" FontFamily="Segoe MDL2 Assets" Text="&#xE972;"  Canvas.Left="145" Canvas.Top="13" Canvas.ZIndex="100"/>
-                    <ComboBox VerticalAlignment="Center" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" MinHeight="40" x:Name="Fonts" PlaceholderText="Segoe UI" SelectionChanged="Fonts_SelectionChanged" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1" PlaceholderForeground="Black"/>
+                    <ComboBox VerticalAlignment="Center" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" MinHeight="40" x:Name="Fonts" ItemsSource="{x:Bind AllFonts, Mode=OneWay}" PlaceholderText="Segoe UI" SelectionChanged="Fonts_SelectionChanged" Width="169" HorizontalAlignment="Left" BorderThickness="1,1,1,1" PlaceholderForeground="Black"/>
                 </Canvas>
             </CommandBar.Content>
             <AppBarButton x:Name="TextColor" x:Uid="TextColor" Width="40" Icon="FontColor">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -7,6 +7,7 @@
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
     xmlns:q="using:QuickPad"
+    RequestedTheme="{x:Bind QSetting.Theme, Mode=OneWay}"
     mc:Ignorable="d">
 
     <Page.Background>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -6,6 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
+    xmlns:q="using:QuickPad"
     mc:Ignorable="d">
 
     <Page.Background>
@@ -181,7 +182,7 @@
             </AppBarButton>
         </CommandBar>
 
-        <RichEditBox  x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18"  Style="{StaticResource RichEditBox}"/>
+        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18" TextWrapping="{x:Bind q:Convertor.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
 
         <ContentDialog x:Name="SaveDialog" Windows10version1809:CornerRadius="4" Background="{ThemeResource SystemControlAcrylicElementBrush}" BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}">
 
@@ -226,7 +227,7 @@
                                     <TextBlock x:Uid="AutoSaveSwitch" Text="Auto Save" Margin="0,150,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
                                     <ToggleSwitch x:Name="AutoSaveSwitch" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.AutoSave, Mode=TwoWay}" HorizontalAlignment="Left" Margin="0,170,0,0" VerticalAlignment="Top" />
                                     <TextBlock x:Uid="WordWrap" Text="Word Wrap" Margin="0,215,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
-                                    <ToggleSwitch x:Name="WordWrap" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="WordWrap_Toggled" HorizontalAlignment="Left" Margin="0,235,0,0" VerticalAlignment="Top" />
+                                    <ToggleSwitch x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.WordWrap, Mode=TwoWay}" HorizontalAlignment="Left" Margin="0,235,0,0" VerticalAlignment="Top" />
                                     <TextBlock x:Uid="SpellCheck" Text="Spell Check" Margin="0,280,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
                                     <ToggleSwitch x:Name="SpellCheck" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="SpellCheck_Toggled" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" />
                                 </Grid>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -159,7 +159,7 @@
                 </ToolTipService.ToolTip>
             </AppBarButton>
             <AppBarSeparator x:Name="ASep1"/>
-            <AppBarToggleButton x:Name="CompactOverlay" x:Uid="CompactOverlay" Content="On Top" HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Checked="CompactOverlay_Checked" Unchecked="CompactOverlay_Unchecked">
+            <AppBarToggleButton x:Name="CompactOverlay" x:Uid="CompactOverlay" IsChecked="{x:Bind CompactOverlaySwitch, Mode=TwoWay}" Content="On Top" HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center">
                 <AppBarToggleButton.KeyboardAccelerators>
                     <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
                 </AppBarToggleButton.KeyboardAccelerators>
@@ -213,13 +213,13 @@
                             <ScrollViewer x:Name="SettingsTab1SV" Height="200">
                                 <Grid Height="340">
                                     <TextBlock Text="Launch Mode" x:Uid="GeneralLaunchMode" Margin="0,10,23,87" TextWrapping="Wrap"/>
-                                    <ComboBox Margin="0,35,0,0" x:Uid="GeneralLaunchModeCombobox" PlaceholderText="Default" SelectionChanged="LaunchOptions_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="LaunchOptions" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="125" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
+                                    <ComboBox Margin="0,35,0,0" x:Uid="GeneralLaunchModeCombobox" PlaceholderText="Default" SelectedIndex="{x:Bind QSetting.LaunchMode, Mode=TwoWay}" Windows10version1809:CornerRadius="2" x:Name="LaunchOptions" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="125" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                         <ComboBoxItem Content="Default" Tag="Default" x:Uid="LaunchModeDefault" x:Name="LaunchModeDefault"/>
                                         <ComboBoxItem Content="On Top" Tag="On Top" x:Uid="LaunchModeOnTop" x:Name="LaunchModeOnTop"/>
                                         <ComboBoxItem Content="Focus Mode" Tag="Focus Mode" x:Uid="LaunchModeFocus" x:Name="LaunchModeFocus"/>
                                     </ComboBox>
                                     <TextBlock x:Uid="GeneralDefaultType" Text="Default File Type" Margin="0,80,0,0" TextWrapping="Wrap" FontFamily="Segoe UI"/>
-                                    <ComboBox Margin="0,105,0,0" PlaceholderText=".rtf" SelectionChanged="DefaultFileType_SelectionChanged" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
+                                    <ComboBox Margin="0,105,0,0" PlaceholderText=".rtf" SelectedItem="{x:Bind QSetting.DefaultFileType, Mode=TwoWay}" Windows10version1809:CornerRadius="2" x:Name="DefaultFileType" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" Width="75" HorizontalAlignment="Left" BorderThickness="1,1,1,1">
                                         <x:String>.rtf</x:String>
                                         <x:String>.txt</x:String>
                                     </ComboBox>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -84,7 +84,7 @@
                     <TextBlock Text="Underline (Ctrl+U)" x:Uid="UnderlineTooltip"/>
                 </ToolTipService.ToolTip>
             </AppBarButton>
-            <AppBarButton x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Center" Click="Strikethrough_Click">
+            <AppBarButton x:Name="Strikethrough" x:Uid="Strikethrough" Label="Strikethrough"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowStrikethroughOption), Mode=OneWay}" HorizontalAlignment="Stretch" Margin="0,0,0,0" VerticalAlignment="Center" Click="Strikethrough_Click">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Strikethrough" x:Uid="StrikethroughTooltip"/>
                 </ToolTipService.ToolTip>
@@ -92,28 +92,28 @@
                     <FontIcon Glyph="&#xA7A8;" FontFamily="Segoe UI"/>
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="Visible" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch">
+            <AppBarButton x:Name="BulletList" x:Uid="BulletList"  Label="Bullets"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowBullets), Mode=OneWay}" Icon="List" Click="BulletList_Click" HorizontalAlignment="Stretch">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Toggle Bullets" x:Uid="BuTooltip"/>
                 </ToolTipService.ToolTip>
             </AppBarButton>
             <AppBarSeparator/>
-            <AppBarButton x:Name="Left" x:Uid="Left" Label="Left" Width="Auto" MinWidth="40" Click="Left_Click" Icon="AlignLeft">
+            <AppBarButton x:Name="Left" x:Uid="Left" Label="Left" Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignLeft), Mode=OneWay}" Click="Left_Click" Icon="AlignLeft">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Align left (Ctrl+L)" x:Uid="LeftTooltip"/>
                 </ToolTipService.ToolTip>
             </AppBarButton>
-            <AppBarButton x:Name="Center" x:Uid="Center" Label="Center" Width="Auto" MinWidth="40" Click="Center_Click" Icon="AlignCenter">
+            <AppBarButton x:Name="Center" x:Uid="Center" Label="Center" Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignCenter), Mode=OneWay}" Click="Center_Click" Icon="AlignCenter">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Align center (Ctrl+E)" x:Uid="CenterTooltip"/>
                 </ToolTipService.ToolTip>
             </AppBarButton>
-            <AppBarButton x:Name="Right" x:Uid="Right" Label="Right"  Width="Auto" MinWidth="40" Click="Right_Click" Icon="AlignRight">
+            <AppBarButton x:Name="Right" x:Uid="Right" Label="Right"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignRight), Mode=OneWay}" Click="Right_Click" Icon="AlignRight">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Align right (Ctrl+R)" x:Uid="RightTooltip"/>
                 </ToolTipService.ToolTip>
             </AppBarButton>
-            <AppBarButton x:Name="Justify" x:Uid="Justify" Label="Justify"  Width="Auto" MinWidth="40" Click="Justify_Click" Background="{x:Null}" >
+            <AppBarButton x:Name="Justify" x:Uid="Justify" Label="Justify"  Width="Auto" MinWidth="40" Visibility="{x:Bind q:Converter.BoolToVisibility(QSetting.ShowAlignJustify), Mode=OneWay}" Click="Justify_Click" Background="{x:Null}" >
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Justify text (Ctrl+J)" x:Uid="JustifyTooltip"/>
                 </ToolTipService.ToolTip>
@@ -121,7 +121,7 @@
                     <BitmapIcon UriSource="/Assets/justify align.png"/>
                 </AppBarButton.Icon>
             </AppBarButton>
-            <AppBarSeparator x:Name="AlignSeparator" />
+            <AppBarSeparator x:Name="AlignSeparator" Visibility="{x:Bind q:Converter.HideIfNoAlignButtonShow(QSetting.ShowAlignLeft, QSetting.ShowAlignCenter, QSetting.ShowAlignRight, QSetting.ShowAlignJustify), Mode=OneWay}" />
             <AppBarButton x:Name="SizeUp" x:Uid="SizeUp" Label="Size Up" Width="Auto" MinWidth="40" Click="SizeUp_Click" Icon="FontIncrease">
                 <ToolTipService.ToolTip>
                     <TextBlock Text="Size Up" x:Uid="SizeUpTooltip"/>
@@ -279,12 +279,12 @@
                         <PivotItem Header="Toolbar" x:Name="SettingsTab4" x:Uid="SettingsTab4">
                             <ScrollViewer x:Name="SettingsTab2SV"  Height="200">
                                 <Grid Height="275">
-                                    <ToggleSwitch x:Name="ShowStrikethrough" x:Uid="ShowStrikethrough" OnContent="Show strikethrough option" OffContent="Hide strikethrough option" Toggled="ShowStrikethrough_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,0"/>
-                                    <ToggleSwitch x:Name="ShowBullets" x:Uid="ShowBullets" OnContent="Show bullet list"  OffContent="Hide bullet list" Toggled="ShowBullets_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0, 50,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignLeft" x:Uid="ShowAlignLeft" OnContent="Show align left"  OffContent="Hide align left" Toggled="ShowAlignLeft_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,95,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignCenter" x:Uid="ShowAlignCenter" OnContent="Show align center"  OffContent="Hide align center" Toggled="ShowAlignCenter_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,140,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignRight" x:Uid="ShowAlignRight" OnContent="Show align right"  OffContent="Hide align right" Toggled="ShowAlignRight_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,185,0,0"/>
-                                    <ToggleSwitch x:Name="ShowAlignJustify" x:Uid="ShowAlignJustify" OnContent="Show align justify"  OffContent="Hide align justify" Toggled="ShowAlignJustify_Toggled" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,230,0,0"/>
+                                    <ToggleSwitch x:Name="ShowStrikethrough" IsOn="{x:Bind QSetting.ShowStrikethroughOption, Mode=TwoWay}" x:Uid="ShowStrikethrough" OnContent="Show strikethrough option" OffContent="Hide strikethrough option" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,0"/>
+                                    <ToggleSwitch x:Name="ShowBullets" IsOn="{x:Bind QSetting.ShowBullets, Mode=TwoWay}" x:Uid="ShowBullets" OnContent="Show bullet list"  OffContent="Hide bullet list" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0, 50,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignLeft" IsOn="{x:Bind QSetting.ShowAlignLeft, Mode=TwoWay}" x:Uid="ShowAlignLeft" OnContent="Show align left"  OffContent="Hide align left" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,95,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignCenter" IsOn="{x:Bind QSetting.ShowAlignCenter, Mode=TwoWay}" x:Uid="ShowAlignCenter" OnContent="Show align center"  OffContent="Hide align center" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,140,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignRight" IsOn="{x:Bind QSetting.ShowAlignRight, Mode=TwoWay}" x:Uid="ShowAlignRight" OnContent="Show align right"  OffContent="Hide align right" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,185,0,0"/>
+                                    <ToggleSwitch x:Name="ShowAlignJustify" IsOn="{x:Bind QSetting.ShowAlignJustify, Mode=TwoWay}" x:Uid="ShowAlignJustify" OnContent="Show align justify"  OffContent="Hide align justify" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,230,0,0"/>
                                 </Grid>
                             </ScrollViewer>
                         </PivotItem>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -182,7 +182,7 @@
             </AppBarButton>
         </CommandBar>
 
-        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18" TextWrapping="{x:Bind q:Convertor.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
+        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18" TextWrapping="{x:Bind q:Converter.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
 
         <ContentDialog x:Name="SaveDialog" Windows10version1809:CornerRadius="4" Background="{ThemeResource SystemControlAcrylicElementBrush}" BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}">
 
@@ -236,9 +236,9 @@
                         <PivotItem Header="Theme" x:Name="SettingsTab2" x:Uid="SettingsTab2">
                             <Grid Height="200">
                                 <TextBlock x:Uid="AppTheme" Text="App Theme" Margin="0,5,0,0" TextWrapping="Wrap" FontSize="18"/>
-                                <RadioButton x:Name="Light" x:Uid="Light" Content="Light" HorizontalAlignment="Left" Height="38" Margin="0,40,0,0" VerticalAlignment="Top" Width="242" Click="Light_Click" Grid.RowSpan="2"/>
-                                <RadioButton x:Name="Dark" x:Uid="Dark" Content="Dark" HorizontalAlignment="Left" Height="38" Margin="0,80,0,0" VerticalAlignment="Top" Width="242" Click="Dark_Click"/>
-                                <RadioButton x:Name="SystemDefault" x:Uid="SystemDefault" IsChecked="True" Content="System Default" HorizontalAlignment="Left" Height="38" Margin="0,120,0,0" VerticalAlignment="Top"  Width="242" Click="SystemDefault_Click" Grid.RowSpan="1"/>
+                                <RadioButton x:Name="Light" Tag="Light" x:Uid="Light" Content="Light" HorizontalAlignment="Left" Height="38" Margin="0,40,0,0" VerticalAlignment="Top" Width="242" Click="{x:Bind SetTheme}" IsChecked="{x:Bind q:Converter.ThemeToBool(QSetting.Theme, 'Light'), Mode=OneWay}" Grid.RowSpan="2"/>
+                                <RadioButton x:Name="Dark" Tag="Dark" x:Uid="Dark" Content="Dark" HorizontalAlignment="Left" Height="38" Margin="0,80,0,0" VerticalAlignment="Top" Width="242" Click="{x:Bind SetTheme}" IsChecked="{x:Bind q:Converter.ThemeToBool(QSetting.Theme, 'Dark'), Mode=OneWay}"/>
+                                <RadioButton x:Name="SystemDefault" Tag="Default" x:Uid="SystemDefault" Content="System Default" HorizontalAlignment="Left" Height="38" Margin="0,120,0,0" VerticalAlignment="Top"  Width="242" Click="{x:Bind SetTheme}" IsChecked="{x:Bind q:Converter.ThemeToBool(QSetting.Theme, 'Default'), Mode=OneWay}" Grid.RowSpan="1"/>
                             </Grid>
                         </PivotItem>
                         <PivotItem Header="Font" x:Name="SettingsTab3" x:Uid="SettingsTab3">

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -182,7 +182,7 @@
             </AppBarButton>
         </CommandBar>
 
-        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18" TextWrapping="{x:Bind q:Convertor.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
+        <RichEditBox x:Name="Text1" Drop="Text1_Drop" TextChanging="Text1_TextChanging" SelectionChanged="Text1_SelectionChanged" DragOver="Text1_DragOver" KeyDown="Text1_KeyDown" TextChanged="Text1_TextChanged"  Margin="0,74,0,40" GotFocus="Text1_GotFocus" BorderThickness="0,0,0,0" MinHeight="0" MinWidth="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" RequestedTheme="Default" FontSize="18" TextWrapping="{x:Bind q:Convertor.BoolToTextWrap(QSetting.WordWrap), Mode=OneWay}" IsSpellCheckEnabled="{x:Bind QSetting.SpellCheck, Mode=OneWay}" Style="{StaticResource RichEditBox}"/>
 
         <ContentDialog x:Name="SaveDialog" Windows10version1809:CornerRadius="4" Background="{ThemeResource SystemControlAcrylicElementBrush}" BorderBrush="{ThemeResource SystemControlForegroundBaseLowBrush}">
 
@@ -229,7 +229,7 @@
                                     <TextBlock x:Uid="WordWrap" Text="Word Wrap" Margin="0,215,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
                                     <ToggleSwitch x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.WordWrap, Mode=TwoWay}" HorizontalAlignment="Left" Margin="0,235,0,0" VerticalAlignment="Top" />
                                     <TextBlock x:Uid="SpellCheck" Text="Spell Check" Margin="0,280,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
-                                    <ToggleSwitch x:Name="SpellCheck" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="SpellCheck_Toggled" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" />
+                                    <ToggleSwitch x:Name="SpellCheck" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.SpellCheck, Mode=TwoWay}" HorizontalAlignment="Left" Margin="0,300,0,0" VerticalAlignment="Top" />
                                 </Grid>
                             </ScrollViewer>
                         </PivotItem>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -733,9 +733,10 @@
         </controls:DropShadowPanel>
         <Grid x:Name="Title" Canvas.ZIndex="100" Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}" VerticalAlignment="Top" Height="33" HorizontalAlignment="Stretch" Margin="0,0,0,0">
             <StackPanel Orientation="Horizontal">
-                <TextBlock x:Name="TQuick" Text="Quick Pad"
+                <TextBlock Text="{x:Bind CurrentFilename, Mode=OneWay}"
                            Style="{ThemeResource CaptionTextBlockStyle}"
-                           VerticalAlignment="Center" Margin="10,0,0,0" FontSize="14"/>
+                           VerticalAlignment="Center" Margin="10,0,0,0" FontSize="14"
+                           Visibility="{x:Bind q:Converter.BoolToVisibilityInvert(CompactOverlaySwitch), Mode=OneWay}"/>
             </StackPanel>
         </Grid>
     </Grid>

--- a/Quick Pad/MainPage.xaml
+++ b/Quick Pad/MainPage.xaml
@@ -224,7 +224,7 @@
                                         <x:String>.txt</x:String>
                                     </ComboBox>
                                     <TextBlock x:Uid="AutoSaveSwitch" Text="Auto Save" Margin="0,150,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
-                                    <ToggleSwitch x:Name="AutoSaveSwitch" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="AutoSaveSwitch_Toggled" HorizontalAlignment="Left" Margin="0,170,0,0" VerticalAlignment="Top" />
+                                    <ToggleSwitch x:Name="AutoSaveSwitch" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" IsOn="{x:Bind QSetting.AutoSave, Mode=TwoWay}" HorizontalAlignment="Left" Margin="0,170,0,0" VerticalAlignment="Top" />
                                     <TextBlock x:Uid="WordWrap" Text="Word Wrap" Margin="0,215,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>
                                     <ToggleSwitch x:Name="WordWrap" x:Uid="GeneralToggleSwitch" OnContent="On" OffContent="Off" Toggled="WordWrap_Toggled" HorizontalAlignment="Left" Margin="0,235,0,0" VerticalAlignment="Top" />
                                     <TextBlock x:Uid="SpellCheck" Text="Spell Check" Margin="0,280,23,12" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" FontFamily="Segoe UI"/>

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -223,16 +223,10 @@ namespace Quick_Pad_Free_Edition
                 timer.AutoReset = true;
             }
 
-            //check how many times the app was run
-            String NewUser = localSettings.Values["NewUser"] as string;
-            if (NewUser == "1") //second time using the app
+            QSetting.NewUser++;
+            if (QSetting.NewUser == 1)
             {
-                localSettings.Values["NewUser"] = "2";
                 NewUserFeedbackAsync(); //call method that asks user if they want to review the app
-            }
-            if (NewUser != "1" && NewUser != "2") //first time using the app
-            {
-                localSettings.Values["NewUser"] = "1";
             }
         }
 

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -217,19 +217,6 @@ namespace Quick_Pad_Free_Edition
                 timer.AutoReset = true;
             }
 
-            //check if spell check is on or off
-            String spellchecksetting = localSettings.Values["SpellCheck"] as string;
-            if (spellchecksetting == "No")
-            {
-                SpellCheck.IsOn = false; //keep spell check switch off in settings panel.
-                Text1.IsSpellCheckEnabled = false; //turn spell check off
-            }
-            else
-            {
-                SpellCheck.IsOn = true; //turn spell check switch on in settings panel.
-                Text1.IsSpellCheckEnabled = true; //turn spell on
-            }
-
             //check how many times the app was run
             String NewUser = localSettings.Values["NewUser"] as string;
             if (NewUser == "1") //second time using the app
@@ -1325,24 +1312,6 @@ namespace Quick_Pad_Free_Edition
         private void FontSelected_PointerExited(object sender, PointerRoutedEventArgs e)
         {
             FontBoxFrame.Background = Fonts.Background; //Make the frame over the font box the same color as the font box
-        }
-
-        private void SpellCheck_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["SpellCheck"] = "Yes";
-                    Text1.IsSpellCheckEnabled = true;
-                }
-                else
-                {
-                    localSettings.Values["SpellCheck"] = "No";
-                    Text1.IsSpellCheckEnabled = false;
-                }
-            }
         }
 
         private void DefaultFont_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using QuickPad;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -230,15 +231,21 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
+        ObservableCollection<string> _fonts;
+        public ObservableCollection<string> AllFonts
+        {
+            get => _fonts;
+            set => Set(ref _fonts, value);
+        }
+        
         private void LoadFonts()
         {
-            //add all installed fonts to the font box
-            string[] fonts = Microsoft.Graphics.Canvas.Text.CanvasTextFormat.GetSystemFontFamilies();
-            foreach (string font in fonts)
-            {
-                Fonts.Items.Add(string.Format(font));
-                DefaultFont.Items.Add(string.Format(font));
-            }
+            //Load all fonts
+            List<string> fonts = Microsoft.Graphics.Canvas.Text.CanvasTextFormat.GetSystemFontFamilies().ToList();
+            //Sort it in alphabet order
+            fonts.Sort((fontA, fontB) => fontA.CompareTo(fontB));
+            //Put it on an observable list
+            AllFonts = new ObservableCollection<string>(fonts);
         }
 
         private void CheckTheme()
@@ -266,23 +273,11 @@ namespace Quick_Pad_Free_Edition
             {
                 Text1.Focus(FocusState.Programmatic); // Set focus on the main content so the user can start typing right away
 
-                //check what the default font is
-                try
-                {
-                    String DefaultFonts = localSettings.Values["DefaultFont"] as string;
-                    if (DefaultFonts != "Segoe UI")
-                    {
-                        DefaultFont.PlaceholderText = DefaultFonts;
-                        Fonts.PlaceholderText = DefaultFonts;
-                        Fonts.SelectedItem = DefaultFonts;
-                        FontSelected.Text = Convert.ToString(Fonts.SelectedItem);
-                        Text1.Document.Selection.CharacterFormat.Name = DefaultFonts;
-                    }
-                }
-                catch (Exception)
-                {
-                    localSettings.Values["DefaultFont"] = "Segoe UI"; //set the default font size to Segoe UI
-                }
+                //set default font to UIs that still not depend on binding
+                Fonts.PlaceholderText = QSetting.DefaultFont;
+                Fonts.SelectedItem = QSetting.DefaultFont;
+                FontSelected.Text = Convert.ToString(Fonts.SelectedItem);
+                Text1.Document.Selection.CharacterFormat.Name = QSetting.DefaultFont;
 
                 //check what default font color is
                 try

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -209,15 +209,8 @@ namespace Quick_Pad_Free_Edition
         private void LoadSettings()
         {
             //check if auto save is on or off
-            String launchValue = localSettings.Values["AutoSave"] as string;
-            if (launchValue == "Off")
+            if (QSetting.AutoSave)
             {
-                AutoSaveSwitch.IsOn = false; //keep auto save switch off in settings panel.
-            }
-            else
-            {
-                AutoSaveSwitch.IsOn = true; //turn auto save switch on in settings panel.
-
                 //start auto save timer
                 timer.Enabled = true;
                 timer.Elapsed += new System.Timers.ElapsedEventHandler(send);
@@ -1116,24 +1109,6 @@ namespace Quick_Pad_Free_Edition
                 {
                     richEditBox.Document.Selection.TypeText("\t");
                     e.Handled = true;
-                }
-            }
-        }
-
-        private void AutoSaveSwitch_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-        
-                    localSettings.Values["AutoSave"] = "On";
-                }
-                else
-                {
-        
-                    localSettings.Values["AutoSave"] = "Off";
                 }
             }
         }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -189,6 +189,13 @@ namespace Quick_Pad_Free_Edition
                 NotifyPropertyChanged(nameof(CompactOverlaySwitch));
             }
         }
+
+        public void SetTheme(object sender, RoutedEventArgs e)
+        {
+            QSetting.Theme = (ElementTheme)Enum.Parse(typeof(ElementTheme), (sender as RadioButton).Tag as string);
+            //Update system theme
+            CheckTheme();
+        }
         #endregion
 
         public void LaunchCheck()
@@ -245,27 +252,9 @@ namespace Quick_Pad_Free_Edition
         {
             //get some theme settings in
             ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
-
-            String localValue = localSettings.Values["Theme"] as string;
-            if (localValue == "Light") //light theme is on
-            {
-                this.RequestedTheme = ElementTheme.Light;
-                Light.IsChecked = true; //select the light theme option in the settings panel
-                Analytics.TrackEvent("Loaded app in light theme");  //log even in app center
-            }
-            if (localValue == "Dark") //dark theme is on
-            {
-                this.RequestedTheme = ElementTheme.Dark;
-                Dark.IsChecked = true; //select the dark theme option in the settings panel
-
-                Analytics.TrackEvent("Loaded app in dark theme"); //log even in app center
-            }
-            if (localValue == "System Default") //default theme is on
-            {
-                this.RequestedTheme = ElementTheme.Default;
-                SystemDefault.IsChecked = true; //select the default theme option in the settings panel
-            }
-
+            this.RequestedTheme = QSetting.Theme;
+            Analytics.TrackEvent($"Loaded app in {QSetting.Theme.ToString().ToLower()} theme");
+            
             //make the minimize, maximize and close button visible in light theme
             if (App.Current.RequestedTheme == ApplicationTheme.Dark || this.RequestedTheme == ElementTheme.Dark)
             {

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -61,7 +61,7 @@ namespace Quick_Pad_Free_Edition
         public ResourceLoader textResource { get; } = ResourceLoader.GetForCurrentView(); //Use to get a text resource from Strings/en-US
 
         public QuickPad.Setting QSetting { get; } = new QuickPad.Setting(); //Store all app setting here..
-
+                
         private string DefaultFilename => textResource.GetString("NewDocument");
         private string UpdateFile; //Default file name is "New Document"
         private String FullFilePath; //this is the opened files full path
@@ -140,6 +140,7 @@ namespace Quick_Pad_Free_Edition
             this.LayoutUpdated += MainPage_LayoutUpdated;
         }
 
+        #region Startup and function handling (Main_Loaded, Uodate UI, Launch sub function, Navigation hangler
         private void UpdateUIAccordingToNewTheme(ElementTheme to)
         {
             //Is it dark theme or light theme? Just in case if it default, get a theme info from application
@@ -170,66 +171,6 @@ namespace Quick_Pad_Free_Edition
 
             FontBoxFrame.Background = Fonts.Background; //Make the frame over the font box the same color as the font box
         }
-
-        public void send(object source, System.Timers.ElapsedEventArgs e)
-        {
-            //timer for auto save
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                if (TQuick.Text != UpdateFile)
-                {
-                    try
-                    {
-                        var result = FullFilePath.Substring(FullFilePath.Length - 4); //find out the file extension
-                        if ((result.ToLower() != ".rtf"))
-                        {
-                            //tries to update file if it exsits and is not read only
-                            Text1.Document.GetText(TextGetOptions.None, out var value);
-                            await PathIO.WriteTextAsync(FullFilePath, value);
-                            TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
-                        }
-                        if (result.ToLower() == ".rtf")
-                        {
-                            //tries to update file if it exsits and is not read only
-                            Text1.Document.GetText(TextGetOptions.FormatRtf, out var value);
-                            await PathIO.WriteTextAsync(FullFilePath, value);
-                            TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
-                        }
-                    }
-                    catch (Exception) { }
-                }
-            });
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        }
-
-        #region Handle app settings
-        public bool CompactOverlaySwitch
-        {
-            get
-            {
-                return QSetting.LaunchMode == (int)AvailableModes.OnTop;
-            }
-            set
-            {
-                if (value)
-                {
-                    QSetting.LaunchMode = (int)AvailableModes.OnTop;
-                }
-                else
-                {
-                    QSetting.LaunchMode = (int)AvailableModes.Default;
-                }
-                SwitchCompactOverlayMode(value);
-                NotifyPropertyChanged(nameof(CompactOverlaySwitch));
-            }
-        }
-
-        public void SetTheme(object sender, RoutedEventArgs e)
-        {
-            QSetting.Theme = (ElementTheme)Enum.Parse(typeof(ElementTheme), (sender as RadioButton).Tag as string);
-        }
-        #endregion
 
         public void LaunchCheck()
         {
@@ -264,13 +205,6 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
-        ObservableCollection<string> _fonts;
-        public ObservableCollection<string> AllFonts
-        {
-            get => _fonts;
-            set => Set(ref _fonts, value);
-        }
-        
         private void LoadFonts()
         {
             //Load all fonts
@@ -345,6 +279,79 @@ namespace Quick_Pad_Free_Edition
             _isPageLoaded = true;
         }
 
+        #endregion
+        public void send(object source, System.Timers.ElapsedEventArgs e)
+        {
+            //timer for auto save
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
+            {
+                if (TQuick.Text != UpdateFile)
+                {
+                    try
+                    {
+                        var result = FullFilePath.Substring(FullFilePath.Length - 4); //find out the file extension
+                        if ((result.ToLower() != ".rtf"))
+                        {
+                            //tries to update file if it exsits and is not read only
+                            Text1.Document.GetText(TextGetOptions.None, out var value);
+                            await PathIO.WriteTextAsync(FullFilePath, value);
+                            TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
+                        }
+                        if (result.ToLower() == ".rtf")
+                        {
+                            //tries to update file if it exsits and is not read only
+                            Text1.Document.GetText(TextGetOptions.FormatRtf, out var value);
+                            await PathIO.WriteTextAsync(FullFilePath, value);
+                            TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
+                        }
+                    }
+                    catch (Exception) { }
+                }
+            });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+        }
+
+        #region Handle app settings
+        public bool CompactOverlaySwitch
+        {
+            get
+            {
+                return QSetting.LaunchMode == (int)AvailableModes.OnTop;
+            }
+            set
+            {
+                if (value)
+                {
+                    QSetting.LaunchMode = (int)AvailableModes.OnTop;
+                }
+                else
+                {
+                    QSetting.LaunchMode = (int)AvailableModes.Default;
+                }
+                SwitchCompactOverlayMode(value);
+                NotifyPropertyChanged(nameof(CompactOverlaySwitch));
+            }
+        }
+
+        public void SetTheme(object sender, RoutedEventArgs e)
+        {
+            QSetting.Theme = (ElementTheme)Enum.Parse(typeof(ElementTheme), (sender as RadioButton).Tag as string);
+        }
+        #endregion
+
+        #region Properties
+
+        ObservableCollection<string> _fonts;
+        public ObservableCollection<string> AllFonts
+        {
+            get => _fonts;
+            set => Set(ref _fonts, value);
+        }
+
+        #endregion
+
+        #region Store service
         public async void CheckPushNotifications()
         {
             //regisiter for push notifications
@@ -373,6 +380,27 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
+        public async Task<bool> ShowRatingReviewDialog()
+        {
+            StoreSendRequestResult result = await StoreRequestHelper.SendRequestAsync(StoreContext.GetDefault(), 16, String.Empty);
+
+            if (result.ExtendedError == null)
+            {
+                JObject jsonObject = JObject.Parse(result.Response);
+                if (jsonObject.SelectToken("status").ToString() == "success")
+                {
+                    // The customer rated or reviewed the app.
+                    return true;
+                }
+            }
+
+            // There was an error with the request, or the customer chose not to rate or review the app.
+            return false;
+        }
+
+        #endregion
+
+        #region Handling navigation
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
@@ -389,6 +417,9 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
+        #endregion
+
+        #region Load/Save file
         private async Task LoadFasFile(StorageFile file)
         {
             try
@@ -418,12 +449,90 @@ namespace Quick_Pad_Free_Edition
             catch (Exception) { }
         }
 
-        private void SetTaskBarTitle()
+        public async Task SaveWork()
         {
-            var appView = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView();
-            appView.Title = UpdateFile;
-        }
+            try
+            {
+                var result = FullFilePath.Substring(FullFilePath.Length - 4); //find out the file extension
 
+                if ((result.ToLower() != ".rtf"))
+                {
+                    //tries to update file if it exsits and is not read only
+                    Text1.Document.GetText(TextGetOptions.None, out var value);
+                    await PathIO.WriteTextAsync(FullFilePath, value);
+                    TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
+                }
+                if (result.ToLower() == ".rtf")
+                {
+                    //tries to update file if it exsits and is not read only
+                    Text1.Document.GetText(TextGetOptions.FormatRtf, out var value);
+                    await PathIO.WriteTextAsync(FullFilePath, value);
+                    TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
+                }
+            }
+
+            catch (Exception)
+
+            {
+                Windows.Storage.Pickers.FileSavePicker savePicker = new Windows.Storage.Pickers.FileSavePicker();
+
+                savePicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;
+
+                // Dropdown of file types the user can save the file as
+                //check if default file type is .txt
+                if (QSetting.DefaultFileType == ".txt")
+                {
+                    savePicker.FileTypeChoices.Add("Text File", new List<string>() { ".txt" });
+                    savePicker.FileTypeChoices.Add("Rich Text", new List<string>() { ".rtf" });
+                }
+                else if (QSetting.DefaultFileType == ".rtf")
+                {
+                    savePicker.FileTypeChoices.Add("Rich Text", new List<string>() { ".rtf" });
+                    savePicker.FileTypeChoices.Add("Text File", new List<string>() { ".txt" });
+                }
+                savePicker.FileTypeChoices.Add("All Files", new List<string>() { "." });
+
+                // Default file name if the user does not type one in or select a file to replace
+                savePicker.SuggestedFileName = UpdateFile;
+
+                Windows.Storage.StorageFile file = await savePicker.PickSaveFileAsync();
+                if (file != null)
+                {
+                    //update title bar
+                    UpdateFile = file.DisplayName;
+                    TQuick.Text = UpdateFile;
+                    FullFilePath = file.Path;
+                    SetTaskBarTitle(); //update the title in the taskbar
+
+                    key = Windows.Storage.AccessCache.StorageApplicationPermissions.FutureAccessList.Add(file); //let file be accessed later
+
+                    //save as plain text for text file
+                    if ((file.FileType.ToLower() != ".rtf"))
+                    {
+                        Text1.Document.GetText(TextGetOptions.None, out var value); //get the text to save
+                        await FileIO.WriteTextAsync(file, value); //write the text to the file
+                    }
+                    //save as rich text for rich text file
+                    if (file.FileType.ToLower() == ".rtf")
+                    {
+                        Text1.Document.GetText(TextGetOptions.FormatRtf, out var value); //get the text to save
+                        await FileIO.WriteTextAsync(file, value); //write the text to the file
+                    }
+
+                    // Let Windows know that we're finished changing the file so the other app can update the remote version of the file.
+                    Windows.Storage.Provider.FileUpdateStatus status = await Windows.Storage.CachedFileManager.CompleteUpdatesAsync(file);
+                    if (status != Windows.Storage.Provider.FileUpdateStatus.Complete)
+                    {
+                        //let user know if there was an error saving the file
+                        Windows.UI.Popups.MessageDialog errorBox = new Windows.UI.Popups.MessageDialog("File " + file.Name + " couldn't be saved.");
+                        await errorBox.ShowAsync();
+                    }
+                }
+            }
+        }
+        #endregion
+
+        #region Command bar click
         private async void CmdSettings_Click(object sender, RoutedEventArgs e)
         {
             ContentDialogResult result = await Settings.ShowAsync();
@@ -523,88 +632,6 @@ namespace Quick_Pad_Free_Edition
                 }
             }
 
-        }
-
-        public async Task SaveWork()
-        {
-            try
-            {
-                var result = FullFilePath.Substring(FullFilePath.Length - 4); //find out the file extension
-
-                if ((result.ToLower() != ".rtf"))
-                {
-                    //tries to update file if it exsits and is not read only
-                    Text1.Document.GetText(TextGetOptions.None, out var value);
-                    await PathIO.WriteTextAsync(FullFilePath, value);
-                    TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
-                }
-                if (result.ToLower() == ".rtf")
-                {
-                    //tries to update file if it exsits and is not read only
-                    Text1.Document.GetText(TextGetOptions.FormatRtf, out var value);
-                    await PathIO.WriteTextAsync(FullFilePath, value);
-                    TQuick.Text = UpdateFile; //update title bar to indicate file is up to date
-                }
-            }
-
-            catch (Exception)
-
-            {
-                Windows.Storage.Pickers.FileSavePicker savePicker = new Windows.Storage.Pickers.FileSavePicker();
-
-                savePicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;
-
-                // Dropdown of file types the user can save the file as
-                //check if default file type is .txt
-                if (QSetting.DefaultFileType == ".txt")
-                {
-                    savePicker.FileTypeChoices.Add("Text File", new List<string>() { ".txt" });
-                    savePicker.FileTypeChoices.Add("Rich Text", new List<string>() { ".rtf" });
-                }
-                else if (QSetting.DefaultFileType == ".rtf")
-                {
-                    savePicker.FileTypeChoices.Add("Rich Text", new List<string>() { ".rtf" });
-                    savePicker.FileTypeChoices.Add("Text File", new List<string>() { ".txt" });
-                }
-                savePicker.FileTypeChoices.Add("All Files", new List<string>() { "." });
-
-                // Default file name if the user does not type one in or select a file to replace
-                savePicker.SuggestedFileName = UpdateFile;
-
-                Windows.Storage.StorageFile file = await savePicker.PickSaveFileAsync();
-                if (file != null)
-                {
-                    //update title bar
-                    UpdateFile = file.DisplayName;
-                    TQuick.Text = UpdateFile;
-                    FullFilePath = file.Path;
-                    SetTaskBarTitle(); //update the title in the taskbar
-
-                    key = Windows.Storage.AccessCache.StorageApplicationPermissions.FutureAccessList.Add(file); //let file be accessed later
-
-                    //save as plain text for text file
-                    if ((file.FileType.ToLower() != ".rtf"))
-                    {
-                        Text1.Document.GetText(TextGetOptions.None, out var value); //get the text to save
-                        await FileIO.WriteTextAsync(file, value); //write the text to the file
-                    }
-                    //save as rich text for rich text file
-                    if (file.FileType.ToLower() == ".rtf")
-                    {
-                        Text1.Document.GetText(TextGetOptions.FormatRtf, out var value); //get the text to save
-                        await FileIO.WriteTextAsync(file, value); //write the text to the file
-                    }
-
-                    // Let Windows know that we're finished changing the file so the other app can update the remote version of the file.
-                    Windows.Storage.Provider.FileUpdateStatus status = await Windows.Storage.CachedFileManager.CompleteUpdatesAsync(file);
-                    if (status != Windows.Storage.Provider.FileUpdateStatus.Complete)
-                    {
-                        //let user know if there was an error saving the file
-                        Windows.UI.Popups.MessageDialog errorBox = new Windows.UI.Popups.MessageDialog("File " + file.Name + " couldn't be saved.");
-                        await errorBox.ShowAsync();
-                    }
-                }
-            }
         }
 
         public async void CmdSave_Click(object sender, RoutedEventArgs e)
@@ -723,56 +750,6 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
-        public async void SwitchCompactOverlayMode(bool switching)
-        {
-            if (switching)
-            {
-                ViewModePreferences compactOptions = ViewModePreferences.CreateDefault(ApplicationViewMode.CompactOverlay);
-                bool modeSwitched = await ApplicationView.GetForCurrentView().TryEnterViewModeAsync(ApplicationViewMode.CompactOverlay, compactOptions);
-
-                Grid.SetRow(CommandBar2, 2);
-                Shadow1.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                CommandBar1.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                Title.Visibility = Visibility.Collapsed;
-                CommandBar2.HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Stretch;
-                FrameTop.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                Text1.Margin = new Thickness(0, 0, 0, 0);
-                CmdSettings.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                CmdFocusMode.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                CmdFocusMode.IsEnabled = false;
-                CommandBar3.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                CommandBar2.Margin = new Thickness(0, 0, 0, 0);
-                TQuick.Visibility = Visibility.Collapsed;
-
-                //make text smaller size if user did not do so on their own and if they did not type anything yet.
-                Text1.Document.GetText(TextGetOptions.UseCrlf, out var value);
-                if (string.IsNullOrEmpty(value) && Text1.FontSize == 18)
-                {
-                    Text1.FontSize = 16;
-                }
-
-                //log even in app center
-                Analytics.TrackEvent("Compact Overlay");
-            }
-            else
-            {
-                bool modeSwitched = await ApplicationView.GetForCurrentView().TryEnterViewModeAsync(ApplicationViewMode.Default);
-                Grid.SetRow(CommandBar2, 0);
-                Title.Visibility = Visibility.Visible;
-                Shadow1.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                CommandBar1.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                CommandBar2.HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Right;
-                FrameTop.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                CmdSettings.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                CmdFocusMode.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                CommandBar3.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                TQuick.Visibility = Visibility.Visible;
-                CmdFocusMode.IsEnabled = true;
-                Text1.Margin = new Thickness(0, 74, 0, 40);
-                CommandBar2.Margin = new Thickness(0, 33, 0, 0);
-            }
-        }
-
         private void Emoji_Checked(object sender, RoutedEventArgs e)
         {
             Emoji2.Visibility = Windows.UI.Xaml.Visibility.Visible;
@@ -878,24 +855,6 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
-        public async Task<bool> ShowRatingReviewDialog()
-        {
-            StoreSendRequestResult result = await StoreRequestHelper.SendRequestAsync(StoreContext.GetDefault(), 16, String.Empty);
-
-            if (result.ExtendedError == null)
-            {
-                JObject jsonObject = JObject.Parse(result.Response);
-                if (jsonObject.SelectToken("status").ToString() == "success")
-                {
-                    // The customer rated or reviewed the app.
-                    return true;
-                }
-            }
-
-            // There was an error with the request, or the customer chose not to rate or review the app.
-            return false;
-        }
-
         private async void CmdReview_Click(object sender, RoutedEventArgs e)
         {
             await ShowRatingReviewDialog(); //show the review dialog.
@@ -940,80 +899,6 @@ namespace Quick_Pad_Free_Edition
         private void Settings_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
         {
             SettingsPivot.SelectedItem = SettingsTab1; //Set focus to first item in pivot control in the settings panel
-        }
-
-        private void Text1_KeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            if (e.Key == VirtualKey.Tab)
-            {
-                RichEditBox richEditBox = sender as RichEditBox;
-                if (richEditBox != null)
-                {
-                    richEditBox.Document.Selection.TypeText("\t");
-                    e.Handled = true;
-                }
-            }
-        }
-
-        private void Text1_DragOver(object sender, DragEventArgs e)
-        {
-            e.AcceptedOperation = DataPackageOperation.Copy;
-        }
-
-        private async void Text1_Drop(object sender, DragEventArgs e)
-        {
-            //Check if file is open and ask user if they want to save it when dragging a file in to Quick Pad.
-            if (TQuick.Text != UpdateFile)
-            {
-                await SaveDialog.ShowAsync();
-                if (SaveDialogValue == "Cancel")
-                {
-                    SaveDialogValue = ""; //reset save dialog value
-                    return;
-                }
-            }
-
-            //load rich text files dropped in from file explorer
-            try
-            {
-                if (e.DataView.Contains(StandardDataFormats.StorageItems))
-                {
-                    var items = await e.DataView.GetStorageItemsAsync();
-                    if (items.Count > 0)
-                    {
-                        var storageFile = items[0] as StorageFile;
-                        var read = await FileIO.ReadTextAsync(storageFile);
-
-                        Windows.Storage.Streams.IRandomAccessStream randAccStream = await storageFile.OpenAsync(Windows.Storage.FileAccessMode.Read);
-
-                        key = Windows.Storage.AccessCache.StorageApplicationPermissions.FutureAccessList.Add(storageFile); //let file be accessed later
-
-                        if ((storageFile.FileType.ToLower() != ".rtf"))
-                        {
-                            Text1.Document.SetText(Windows.UI.Text.TextSetOptions.None, await FileIO.ReadTextAsync(storageFile));
-                        }
-
-                        if (storageFile.FileType.ToLower() == ".rtf")
-                        {
-                            Text1.Document.LoadFromStream(Windows.UI.Text.TextSetOptions.FormatRtf, randAccStream);
-                        }
-
-                        UpdateFile = storageFile.DisplayName;
-                        TQuick.Text = UpdateFile;
-                        FullFilePath = storageFile.Path;
-                        SetTaskBarTitle(); //update the title in the taskbar
-
-                        //log even in app center
-                        Analytics.TrackEvent("Droped file in to Quick Pad");
-                    }
-                }
-            }
-            catch (Exception) { }
-        }
-        
-        private void Text1_SelectionChanged(object sender, RoutedEventArgs e)
-        {
-            FontSelected.Text = Text1.Document.Selection.CharacterFormat.Name; //updates font box to show the selected characters font
         }
 
         private void Fonts_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -1090,6 +975,64 @@ namespace Quick_Pad_Free_Edition
             localSettings.Values["DefaultFontColor"] = (DefaultFontColor.SelectedValue as ComboBoxItem).Tag;
             Text1.Document.Selection.CharacterFormat.ForegroundColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), (DefaultFontColor.SelectedValue as ComboBoxItem).Tag);
         }
+        #endregion
+
+        #region UI Mode change
+        public async void SwitchCompactOverlayMode(bool switching)
+        {
+            if (switching)
+            {
+                ViewModePreferences compactOptions = ViewModePreferences.CreateDefault(ApplicationViewMode.CompactOverlay);
+                bool modeSwitched = await ApplicationView.GetForCurrentView().TryEnterViewModeAsync(ApplicationViewMode.CompactOverlay, compactOptions);
+
+                Grid.SetRow(CommandBar2, 2);
+                Shadow1.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                CommandBar1.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                Title.Visibility = Visibility.Collapsed;
+                CommandBar2.HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Stretch;
+                FrameTop.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                Text1.Margin = new Thickness(0, 0, 0, 0);
+                CmdSettings.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                CmdFocusMode.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                CmdFocusMode.IsEnabled = false;
+                CommandBar3.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                CommandBar2.Margin = new Thickness(0, 0, 0, 0);
+                TQuick.Visibility = Visibility.Collapsed;
+
+                //make text smaller size if user did not do so on their own and if they did not type anything yet.
+                Text1.Document.GetText(TextGetOptions.UseCrlf, out var value);
+                if (string.IsNullOrEmpty(value) && Text1.FontSize == 18)
+                {
+                    Text1.FontSize = 16;
+                }
+
+                //log even in app center
+                Analytics.TrackEvent("Compact Overlay");
+            }
+            else
+            {
+                bool modeSwitched = await ApplicationView.GetForCurrentView().TryEnterViewModeAsync(ApplicationViewMode.Default);
+                Grid.SetRow(CommandBar2, 0);
+                Title.Visibility = Visibility.Visible;
+                Shadow1.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                CommandBar1.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                CommandBar2.HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Right;
+                FrameTop.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                CmdSettings.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                CmdFocusMode.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                CommandBar3.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                TQuick.Visibility = Visibility.Visible;
+                CmdFocusMode.IsEnabled = true;
+                Text1.Margin = new Thickness(0, 74, 0, 40);
+                CommandBar2.Margin = new Thickness(0, 33, 0, 0);
+            }
+        }
+
+        private void SetTaskBarTitle()
+        {
+            var appView = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView();
+            appView.Title = UpdateFile;
+        }
 
         private void SwitchToFocusMode()
         {
@@ -1100,12 +1043,12 @@ namespace Quick_Pad_Free_Edition
             Shadow1.Visibility = Visibility.Collapsed;
             CloseFocusMode.Visibility = Visibility.Visible;
         }
+
         private void CmdFocusMode_Click(object sender, RoutedEventArgs e)
         {
             SwitchToFocusMode();
         }
-
-      
+              
         private void CloseFocusMode_Click(object sender, RoutedEventArgs e)
         {
             Text1.SetValue(Canvas.ZIndexProperty, 0);
@@ -1115,10 +1058,88 @@ namespace Quick_Pad_Free_Edition
             CloseFocusMode.Visibility = Visibility.Collapsed;
             Text1.Margin = new Thickness(0, 74, 0, 40);
         }
+        #endregion
 
+        #region Textbox function
         private void Text1_TextChanging(RichEditBox sender, RichEditBoxTextChangingEventArgs args)
         {
             TQuick.Text = "*" + UpdateFile; //add star to title bar to indicate unsaved file
         }
+
+        private void Text1_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.Key == VirtualKey.Tab)
+            {
+                RichEditBox richEditBox = sender as RichEditBox;
+                if (richEditBox != null)
+                {
+                    richEditBox.Document.Selection.TypeText("\t");
+                    e.Handled = true;
+                }
+            }
+        }
+
+        private void Text1_DragOver(object sender, DragEventArgs e)
+        {
+            e.AcceptedOperation = DataPackageOperation.Copy;
+        }
+
+        private async void Text1_Drop(object sender, DragEventArgs e)
+        {
+            //Check if file is open and ask user if they want to save it when dragging a file in to Quick Pad.
+            if (TQuick.Text != UpdateFile)
+            {
+                await SaveDialog.ShowAsync();
+                if (SaveDialogValue == "Cancel")
+                {
+                    SaveDialogValue = ""; //reset save dialog value
+                    return;
+                }
+            }
+
+            //load rich text files dropped in from file explorer
+            try
+            {
+                if (e.DataView.Contains(StandardDataFormats.StorageItems))
+                {
+                    var items = await e.DataView.GetStorageItemsAsync();
+                    if (items.Count > 0)
+                    {
+                        var storageFile = items[0] as StorageFile;
+                        var read = await FileIO.ReadTextAsync(storageFile);
+
+                        Windows.Storage.Streams.IRandomAccessStream randAccStream = await storageFile.OpenAsync(Windows.Storage.FileAccessMode.Read);
+
+                        key = Windows.Storage.AccessCache.StorageApplicationPermissions.FutureAccessList.Add(storageFile); //let file be accessed later
+
+                        if ((storageFile.FileType.ToLower() != ".rtf"))
+                        {
+                            Text1.Document.SetText(Windows.UI.Text.TextSetOptions.None, await FileIO.ReadTextAsync(storageFile));
+                        }
+
+                        if (storageFile.FileType.ToLower() == ".rtf")
+                        {
+                            Text1.Document.LoadFromStream(Windows.UI.Text.TextSetOptions.FormatRtf, randAccStream);
+                        }
+
+                        UpdateFile = storageFile.DisplayName;
+                        TQuick.Text = UpdateFile;
+                        FullFilePath = storageFile.Path;
+                        SetTaskBarTitle(); //update the title in the taskbar
+
+                        //log even in app center
+                        Analytics.TrackEvent("Droped file in to Quick Pad");
+                    }
+                }
+            }
+            catch (Exception) { }
+        }
+
+        private void Text1_SelectionChanged(object sender, RoutedEventArgs e)
+        {
+            FontSelected.Text = Text1.Document.Selection.CharacterFormat.Name; //updates font box to show the selected characters font
+        }
+
+        #endregion
     }
 }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -215,7 +215,7 @@ namespace Quick_Pad_Free_Edition
             }
 
             QSetting.NewUser++;
-            if (QSetting.NewUser == 1)
+            if (QSetting.NewUser == 2)
             {
                 NewUserFeedbackAsync(); //call method that asks user if they want to review the app
             }

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -86,7 +86,6 @@ namespace Quick_Pad_Free_Edition
 
             LoadSettings();
             LoadFonts();
-            CheckToolbarOptions(); //check which buttons to show in toolbar
             CheckTheme(); //check the theme
 
             VersionNumber.Text = string.Format(textResource.GetString("VersionFormat"), Package.Current.Id.Version.Major, Package.Current.Id.Version.Minor, Package.Current.Id.Version.Build, Package.Current.Id.Version.Revision);
@@ -263,98 +262,6 @@ namespace Quick_Pad_Free_Edition
             if (App.Current.RequestedTheme == ApplicationTheme.Light || this.RequestedTheme == ElementTheme.Light)
             {
                 titleBar.ButtonForegroundColor = Colors.Black;
-            }
-        }
-
-        //check which buttons to show in toolbar
-        private void CheckToolbarOptions()
-        {
-            //check if the bullet list option should show
-            String ShowBulletsSetting = localSettings.Values["ShowBullets"] as string;
-
-            if (ShowBulletsSetting == "No")
-            {
-                ShowBullets.IsOn = false; //toggle the show bullets option in the settings panel.
-                BulletList.Visibility = Visibility.Collapsed; //hid bullet option
-            }
-            else
-            {
-                ShowBullets.IsOn = true; //toggle the show bullets option in the settings panel.
-            }
-
-            //check if strikethrough option should show
-            String ShowST = localSettings.Values["ShowStrikethroughOption"] as string;
-
-            if (ShowST == "No")
-            {
-                //hide ShowStrikethroughOption
-                ShowStrikethrough.IsOn = false; //toggle the show ShowStrikethroughOption option in the settings panel.
-                Strikethrough.Visibility = Visibility.Collapsed; //hide strikethrough option
-            }
-            else
-            {
-                ShowStrikethrough.IsOn = true; //toggle the show ShowStrikethroughOption option in the settings panel.
-            }
-
-            //check if the left align option should show
-            String ShowAl = localSettings.Values["ShowAlignLeft"] as string;
-
-            if (ShowAl == "No")
-            {
-                //hide option
-                ShowAlignLeft.IsOn = false; //toggle the option in the settings panel.
-                Left.Visibility = Visibility.Collapsed; //hide the button
-            }
-            else
-            {
-                ShowAlignLeft.IsOn = true; //toggle the option in the settings panel.
-            }
-
-            //check if the center align option should show
-            String ShowAC = localSettings.Values["ShowAlignCenter"] as string;
-
-            if (ShowAC == "No")
-            {
-                //hide option
-                ShowAlignCenter.IsOn = false; //toggle the option in the settings panel.
-                Center.Visibility = Visibility.Collapsed; //hide the button
-            }
-            else
-            {
-                ShowAlignCenter.IsOn = true; //toggle the option in the settings panel.
-            }
-
-            //check if the right align option should show
-            String ShowAR = localSettings.Values["ShowAlignRight"] as string;
-
-            if (ShowAR == "No")
-            {
-                //hide option
-                ShowAlignRight.IsOn = false; //toggle the option in the settings panel.
-                Right.Visibility = Visibility.Collapsed; //hide the button
-            }
-            else
-            {
-                ShowAlignRight.IsOn = true; //toggle the option in the settings panel.
-            }
-
-            //check if the justify align option should show
-            String ShowAJ = localSettings.Values["ShowAlignJustify"] as string;
-
-            if (ShowAJ == "No")
-            {
-                //hide option
-                ShowAlignJustify.IsOn = false; //toggle the option in the settings panel.
-                Justify.Visibility = Visibility.Collapsed; //hide the button
-            }
-            else
-            {
-                ShowAlignJustify.IsOn = true; //toggle the option in the settings panel.
-            }
-
-            if (ShowAl == "No" && ShowAC == "No" && ShowAR == "No" && ShowAJ == "No")
-            {
-                AlignSeparator.Visibility = Visibility.Collapsed; //hide the separator if all the allignment buttons are hidden
             }
         }
 
@@ -1076,42 +983,6 @@ namespace Quick_Pad_Free_Edition
             }
         }
 
-        private void ShowBullets_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["ShowBullets"] = "Yes";
-                    BulletList.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    localSettings.Values["ShowBullets"] = "No";
-                    BulletList.Visibility = Visibility.Collapsed;
-                }
-            }
-        }
-
-        private void ShowStrikethrough_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["ShowStrikethroughOption"] = "Yes";
-                    Strikethrough.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    localSettings.Values["ShowStrikethroughOption"] = "No";
-                    Strikethrough.Visibility = Visibility.Collapsed;
-                }
-            }
-        }
-
         private void Text1_DragOver(object sender, DragEventArgs e)
         {
             e.AcceptedOperation = DataPackageOperation.Copy;
@@ -1168,101 +1039,9 @@ namespace Quick_Pad_Free_Edition
             catch (Exception) { }
         }
         
-        private void ShowAlignLeft_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["ShowAlignLeft"] = "Yes";
-                    Left.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    localSettings.Values["ShowAlignLeft"] = "No";
-                    Left.Visibility = Visibility.Collapsed;
-                }
-            }
-
-            AlignCheck();
-        }
-
-        private void ShowAlignCenter_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["ShowAlignCenter"] = "Yes";
-                    Center.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    localSettings.Values["ShowAlignCenter"] = "No";
-                    Center.Visibility = Visibility.Collapsed;
-                }
-            }
-
-            AlignCheck();
-        }
-
-        private void ShowAlignRight_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["ShowAlignRight"] = "Yes";
-                    Right.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    localSettings.Values["ShowAlignRight"] = "No";
-                    Right.Visibility = Visibility.Collapsed;
-                }
-            }
-
-            AlignCheck();
-        }
-
-        private void ShowAlignJustify_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["ShowAlignJustify"] = "Yes";
-                    Justify.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    localSettings.Values["ShowAlignJustify"] = "No";
-                    Justify.Visibility = Visibility.Collapsed;
-                }
-            }
-
-            AlignCheck();
-        }
-
         private void Text1_SelectionChanged(object sender, RoutedEventArgs e)
         {
             FontSelected.Text = Text1.Document.Selection.CharacterFormat.Name; //updates font box to show the selected characters font
-        }
-
-        public void AlignCheck()
-        {
-            if (Left.Visibility == Visibility.Collapsed && Center.Visibility == Visibility.Collapsed && Right.Visibility == Visibility.Collapsed && Justify.Visibility == Visibility.Collapsed)
-            {
-                AlignSeparator.Visibility = Visibility.Collapsed; //hide the separator if all the allignment buttons are hidden
-            }
-            else
-            {
-                AlignSeparator.Visibility = Visibility.Visible; //Show the separator if not all the allignment buttons are hidden
-            }
         }
 
         private void Fonts_SelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -215,7 +215,6 @@ namespace Quick_Pad_Free_Edition
             }
 
             QSetting.NewUser++;
-            Analytics.TrackEvent($"The app has been launch for the {QSetting.NewUser} time{(QSetting.NewUser > 1 ? "s" : "")}");
             if (QSetting.NewUser == 1)
             {
                 NewUserFeedbackAsync(); //call method that asks user if they want to review the app

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -217,19 +217,6 @@ namespace Quick_Pad_Free_Edition
                 timer.AutoReset = true;
             }
 
-            //check if word wrap is on or off
-            String WordWrapSetting = localSettings.Values["WordWrap"] as string;
-            if (WordWrapSetting == "No")
-            {
-                WordWrap.IsOn = false; //keep word wrap switch off in settings panel.
-                Text1.TextWrapping = TextWrapping.NoWrap; //turn off word wrap
-            }
-            else
-            {
-                WordWrap.IsOn = true; //turn word wrap switch on in settings panel.
-                Text1.TextWrapping = TextWrapping.Wrap; //turn on word wrap
-            }
-
             //check if spell check is on or off
             String spellchecksetting = localSettings.Values["SpellCheck"] as string;
             if (spellchecksetting == "No")
@@ -1204,25 +1191,7 @@ namespace Quick_Pad_Free_Edition
             }
             catch (Exception) { }
         }
-
-        private void WordWrap_Toggled(object sender, RoutedEventArgs e)
-        {
-            ToggleSwitch toggleSwitch = sender as ToggleSwitch;
-            if (toggleSwitch != null)
-            {
-                if (toggleSwitch.IsOn == true)
-                {
-                    localSettings.Values["WordWrap"] = "Yes";
-                    Text1.TextWrapping = TextWrapping.Wrap;
-                }
-                else
-                {
-                    localSettings.Values["WordWrap"] = "No";
-                    Text1.TextWrapping = TextWrapping.NoWrap;
-                }
-            }
-        }
-
+        
         private void ShowAlignLeft_Toggled(object sender, RoutedEventArgs e)
         {
             ToggleSwitch toggleSwitch = sender as ToggleSwitch;

--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -98,8 +98,9 @@ namespace Quick_Pad_Free_Edition
             {
                 var deferral = e.GetDeferral();
 
-                if (!Changed && CurrentWorkingFile is null)
+                if (!Changed)
                 {
+                    //No change made, either new document or file saved
                     deferral.Complete();
                 }
 
@@ -520,6 +521,7 @@ namespace Quick_Pad_Free_Edition
                 //tries to update file if it exsits and is not read only
                 Text1.Document.GetText(option, out var value);
                 await FileIO.WriteTextAsync(CurrentWorkingFile, value);
+                Changed = false; //Change has been write into fike, mark document as no change has made
             }
             catch (Exception)
             {
@@ -552,6 +554,7 @@ namespace Quick_Pad_Free_Edition
                     //update title bar
                     CurrentWorkingFile = file;
                     CurrentFilename = file.DisplayName;
+                    Changed = false;//Change will be written to file mark as no chage made in document
 
                     key = Windows.Storage.AccessCache.StorageApplicationPermissions.FutureAccessList.Add(file); //let file be accessed later
 

--- a/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
+++ b/Quick Pad/MultilingualResources/Quick Pad.th-TH.xlf
@@ -310,34 +310,6 @@
           <source>Version: {0}.{1}.{2}.{3}</source>
           <target state="translated">เวอร์ชั่น: {0}.{1}.{2}.{3}</target>
         </trans-unit>
-        <trans-unit id="FontColorBlack.Content" translate="yes" xml:space="preserve">
-          <source>Black</source>
-          <target state="translated">ดำ</target>
-        </trans-unit>
-        <trans-unit id="FontColorLightGreen.Content" translate="yes" xml:space="preserve">
-          <source>Green</source>
-          <target state="translated">เขียว</target>
-        </trans-unit>
-        <trans-unit id="FontColorLightPink.Content" translate="yes" xml:space="preserve">
-          <source>Pink</source>
-          <target state="translated">ชมพู</target>
-        </trans-unit>
-        <trans-unit id="FontColorLightSalmon.Content" translate="yes" xml:space="preserve">
-          <source>Orange</source>
-          <target state="translated">ส้ม</target>
-        </trans-unit>
-        <trans-unit id="FontColorLightYellow.Content" translate="yes" xml:space="preserve">
-          <source>Yellow</source>
-          <target state="translated">เหลือง</target>
-        </trans-unit>
-        <trans-unit id="FontColorSkyBlue.Content" translate="yes" xml:space="preserve">
-          <source>Blue</source>
-          <target state="translated">ฟ้า</target>
-        </trans-unit>
-        <trans-unit id="FontColorWhite.Content" translate="yes" xml:space="preserve">
-          <source>White</source>
-          <target state="translated">ขาว</target>
-        </trans-unit>
         <trans-unit id="LaunchModeDefault.Content" translate="yes" xml:space="preserve">
           <source>Default</source>
           <target state="translated">ปกติ</target>
@@ -480,11 +452,39 @@
         </trans-unit>
         <trans-unit id="BlackPlaceholder" translate="yes" xml:space="preserve">
           <source>Black</source>
-          <target state="new">Black</target>
+          <target state="translated">Black</target>
         </trans-unit>
         <trans-unit id="WhitePlaceholder" translate="yes" xml:space="preserve">
           <source>White</source>
-          <target state="new">White</target>
+          <target state="translated" state-qualifier="tm-suggestion">ขาว</target>
+        </trans-unit>
+        <trans-unit id="FontColorBlack" translate="yes" xml:space="preserve">
+          <source>Black</source>
+          <target state="translated" state-qualifier="tm-suggestion">ดำ</target>
+        </trans-unit>
+        <trans-unit id="FontColorBlue" translate="yes" xml:space="preserve">
+          <source>Blue</source>
+          <target state="translated" state-qualifier="tm-suggestion">น้ำเงิน</target>
+        </trans-unit>
+        <trans-unit id="FontColorGreen" translate="yes" xml:space="preserve">
+          <source>Green</source>
+          <target state="translated" state-qualifier="tm-suggestion">เขียว</target>
+        </trans-unit>
+        <trans-unit id="FontColorOrange" translate="yes" xml:space="preserve">
+          <source>Orange</source>
+          <target state="translated" state-qualifier="tm-suggestion">ส้ม</target>
+        </trans-unit>
+        <trans-unit id="FontColorPink" translate="yes" xml:space="preserve">
+          <source>Pink</source>
+          <target state="translated" state-qualifier="tm-suggestion">ชมพู</target>
+        </trans-unit>
+        <trans-unit id="FontColorWhite" translate="yes" xml:space="preserve">
+          <source>White</source>
+          <target state="translated" state-qualifier="tm-suggestion">ขาว</target>
+        </trans-unit>
+        <trans-unit id="FontColorYellow" translate="yes" xml:space="preserve">
+          <source>Yellow</source>
+          <target state="translated" state-qualifier="tm-suggestion">เหลือง</target>
         </trans-unit>
       </group>
     </body>

--- a/Quick Pad/Quick Pad.csproj
+++ b/Quick Pad/Quick Pad.csproj
@@ -137,6 +137,7 @@
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Setting.cs" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -245,6 +246,7 @@
   <ItemGroup>
     <XliffResource Include="MultilingualResources\Quick Pad.th-TH.xlf" />
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -59,7 +59,14 @@ namespace QuickPad
                     previousSetting = false;
                 }
             }
-            else if (propertyName == nameof(WordWrap) || propertyName == nameof(SpellCheck))
+            else if (propertyName == nameof(WordWrap) || 
+                propertyName == nameof(SpellCheck) ||
+                propertyName == nameof(ShowBullets) ||
+                propertyName == nameof(ShowStrikethroughOption) ||
+                propertyName == nameof(ShowAlignLeft) ||
+                propertyName == nameof(ShowAlignCenter) ||
+                propertyName == nameof(ShowAlignRight) ||
+                propertyName == nameof(ShowAlignJustify))
             {
                 //Yes and No to boolean
                 conversion = localSettings.Values[propertyName] as string;
@@ -173,6 +180,50 @@ namespace QuickPad
             set => Set((int)value);
         }
         #endregion
+
+        #region Toolbar setting
+        [DefaultValue(true)]
+        public bool ShowBullets
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool ShowStrikethroughOption
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool ShowAlignLeft
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool ShowAlignCenter
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool ShowAlignRight
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool ShowAlignJustify
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+        #endregion
     }
 
     public enum AvailableModes
@@ -203,6 +254,38 @@ namespace QuickPad
         {
             var convert = (ElementTheme)Enum.Parse(typeof(ElementTheme), expect);
             return Equals(input, convert);
+        }
+
+        /// <summary>
+        /// Use to convert on XAML & x:Bind from bool (or Boolean) to Visibility
+        /// </summary>
+        /// <param name="input">Any boolean input</param>
+        /// <returns>Visibility if true return Visible otherwise return Collapsed</returns>
+        public static Visibility BoolToVisibility(bool input)
+        {
+            if (input)
+            {
+                return Visibility.Visible;
+            }
+            return Visibility.Collapsed;
+        }
+
+        /// <summary>
+        /// A very specific converter use on XAML and x:Bind that only use on align button separator
+        /// By tying all visibility setting into one place and when all 4 is false it will return Visible
+        /// </summary>
+        /// <param name="left">Left align button</param>
+        /// <param name="center">Center align button</param>
+        /// <param name="right">Right align button</param>
+        /// <param name="justify">Justify align button</param>
+        /// <returns></returns>
+        public static Visibility HideIfNoAlignButtonShow(bool left, bool center, bool right, bool justify)
+        {
+            if (!left && !center && !right && !justify)
+            {
+                return Visibility.Collapsed;
+            }
+            return Visibility.Visible;
         }
     }
 }

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -159,10 +159,10 @@ namespace QuickPad
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-#endregion
+        #endregion
         private ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
 
-#region Settings
+        #region Settings
         [DefaultValue((int)(AvailableModes.Default))]
         public int LaunchMode
         {
@@ -184,7 +184,13 @@ namespace QuickPad
         public bool AutoSave
         {
             get => Get<bool>();
-            set => Set(value);
+            set
+            {
+                if (Set(value))
+                {
+                    afterAutoSaveChanged?.Invoke(value);
+                }
+            }
         }
 
         [DefaultValue(true)]
@@ -221,9 +227,9 @@ namespace QuickPad
             get => Get<int>();
             set => Set(value);
         }
-#endregion
+        #endregion
 
-#region Toolbar setting
+        #region Toolbar setting
         [DefaultValue(true)]
         public bool ShowBullets
         {
@@ -265,9 +271,9 @@ namespace QuickPad
             get => Get<bool>();
             set => Set(value);
         }
-#endregion
+        #endregion
 
-#region Font setting
+        #region Font setting
         [DefaultValue("Segoe UI")]
         public string DefaultFont
         {
@@ -281,7 +287,7 @@ namespace QuickPad
             get => Get<string>();
             set => Set(value);
         }
-        
+
         [DefaultValue(18)]
         public int DefaultFontSize
         {
@@ -311,14 +317,16 @@ namespace QuickPad
             get => Get<int>();
             set => Set(value);
         }
-#endregion
+        #endregion
 
-#region Events when setting change
+        #region Events when setting change
+        public autoSaveChange afterAutoSaveChanged { get; set; }
         public themeChange afterThemeChanged { get; set; }
         public fontsizeChange afterFontSizeChanged { get; set; }
 #endregion
     }
 
+    public delegate void autoSaveChange(bool to);
     public delegate void themeChange(ElementTheme to);
     public delegate void fontsizeChange(int to);
 

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -72,6 +72,12 @@ namespace QuickPad
                     previousSetting = false;
                 }
             }
+            else if (propertyName == nameof(Theme))
+            {
+                //Theme string to ElementTheme
+                conversion = localSettings.Values[propertyName] as string;
+                previousSetting = (int)Enum.Parse(typeof(ElementTheme), conversion);
+            }
             #endregion
 
             //Remove old setting
@@ -159,6 +165,13 @@ namespace QuickPad
             get => Get<bool>();
             set => Set(value);
         }
+
+        [DefaultValue(ElementTheme.Default)]
+        public ElementTheme Theme
+        {
+            get => (ElementTheme)Get<int>();
+            set => Set((int)value);
+        }
         #endregion
     }
 
@@ -169,7 +182,7 @@ namespace QuickPad
         Focus //Hide toolbar
     }
 
-    public static class Convertor
+    public static class Converter
     {
         public static TextWrapping BoolToTextWrap(bool input)
         {
@@ -178,6 +191,18 @@ namespace QuickPad
                 return TextWrapping.Wrap;
             }
             return TextWrapping.NoWrap;
+        }
+
+        /// <summary>
+        /// Use to convert on XAML & x:Bind from ElementTheme and string to boolean
+        /// If the ElementTheme match string it will return true, otherwise false
+        /// </summary>
+        /// <param name="input">ThemeElement setting</param>
+        /// <param name="expect">Expected value in string</param>
+        public static bool ThemeToBool(ElementTheme input, string expect)
+        {
+            var convert = (ElementTheme)Enum.Parse(typeof(ElementTheme), expect);
+            return Equals(input, convert);
         }
     }
 }

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -29,7 +29,7 @@ namespace QuickPad
             if (localSettings.Values[propertyName].GetType() == typeof(T))
                 return;
             object previousSetting = default;
-            string conversion = "";
+            string conversion;
 
             #region Setting conversion
             if (propertyName == nameof(LaunchMode))
@@ -123,7 +123,11 @@ namespace QuickPad
                     }
                 }
             }
+#if DEBUG
+            throw new Exception("This setting does not have default setting!");
+#else
             return default(T);
+#endif
         }
 
         /// <summary>
@@ -155,10 +159,10 @@ namespace QuickPad
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-        #endregion
-        ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+#endregion
+        private ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
 
-        #region Settings
+#region Settings
         [DefaultValue((int)(AvailableModes.Default))]
         public int LaunchMode
         {
@@ -217,9 +221,9 @@ namespace QuickPad
             get => Get<int>();
             set => Set(value);
         }
-        #endregion
+#endregion
 
-        #region Toolbar setting
+#region Toolbar setting
         [DefaultValue(true)]
         public bool ShowBullets
         {
@@ -261,9 +265,9 @@ namespace QuickPad
             get => Get<bool>();
             set => Set(value);
         }
-        #endregion
+#endregion
 
-        #region Font setting
+#region Font setting
         public string DefaultFont
         {
             get => Get<string>();
@@ -306,12 +310,12 @@ namespace QuickPad
             get => Get<int>();
             set => Set(value);
         }
-        #endregion
+#endregion
 
-        #region Events when setting change
+#region Events when setting change
         public themeChange afterThemeChanged { get; set; }
         public fontsizeChange afterFontSizeChanged { get; set; }
-        #endregion
+#endregion
     }
 
     public delegate void themeChange(ElementTheme to);

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -85,7 +85,14 @@ namespace QuickPad
             {
                 //Theme string to ElementTheme
                 conversion = localSettings.Values[propertyName] as string;
-                previousSetting = (int)Enum.Parse(typeof(ElementTheme), conversion);
+                if (conversion.StartsWith("System"))
+                {
+                    previousSetting = (int)ElementTheme.Default;
+                }
+                else
+                {
+                    previousSetting = (int)Enum.Parse(typeof(ElementTheme), conversion);
+                }
             }
             else if (propertyName == nameof(NewUser) || propertyName == nameof(DefaultFontSize))
             {

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -59,7 +59,7 @@ namespace QuickPad
                     previousSetting = false;
                 }
             }
-            else if (propertyName == nameof(WordWrap) || 
+            else if (propertyName == nameof(WordWrap) ||
                 propertyName == nameof(SpellCheck) ||
                 propertyName == nameof(ShowBullets) ||
                 propertyName == nameof(ShowStrikethroughOption) ||
@@ -84,6 +84,11 @@ namespace QuickPad
                 //Theme string to ElementTheme
                 conversion = localSettings.Values[propertyName] as string;
                 previousSetting = (int)Enum.Parse(typeof(ElementTheme), conversion);
+            }
+            else if (propertyName == nameof(NewUser))
+            {
+                conversion = localSettings.Values[propertyName] as string;
+                previousSetting = int.Parse(conversion);
             }
             #endregion
 
@@ -178,6 +183,13 @@ namespace QuickPad
         {
             get => (ElementTheme)Get<int>();
             set => Set((int)value);
+        }
+
+        [DefaultValue(0)]
+        public int NewUser
+        {
+            get => Get<int>();
+            set => Set(value);
         }
         #endregion
 

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -268,6 +268,7 @@ namespace QuickPad
 #endregion
 
 #region Font setting
+        [DefaultValue("Segoe UI")]
         public string DefaultFont
         {
             get => Get<string>();

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Windows.Storage;
+using Windows.UI.Xaml;
 
 namespace QuickPad
 {
@@ -50,6 +51,19 @@ namespace QuickPad
                 //On and Off to boolean
                 conversion = localSettings.Values[propertyName] as string;
                 if (conversion == "On")
+                {
+                    previousSetting = true;
+                }
+                else
+                {
+                    previousSetting = false;
+                }
+            }
+            else if (propertyName == nameof(WordWrap))
+            {
+                //Yes and No to boolean
+                conversion = localSettings.Values[propertyName] as string;
+                if (conversion == "Yes")
                 {
                     previousSetting = true;
                 }
@@ -131,6 +145,13 @@ namespace QuickPad
             get => Get<bool>();
             set => Set(value);
         }
+
+        [DefaultValue(true)]
+        public bool WordWrap
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
         #endregion
     }
 
@@ -139,5 +160,17 @@ namespace QuickPad
         Default, //Full UI with toolbar
         OnTop, //Compact overlay
         Focus //Hide toolbar
+    }
+
+    public static class Convertor
+    {
+        public static TextWrapping BoolToTextWrap(bool input)
+        {
+            if (input)
+            {
+                return TextWrapping.Wrap;
+            }
+            return TextWrapping.NoWrap;
+        }
     }
 }

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -45,10 +45,19 @@ namespace QuickPad
                     previousSetting = AvailableModes.Focus;
                 }
             }
-            //else if (propert)
-            //{
-
-            //}
+            else if (propertyName == nameof(AutoSave))
+            {
+                //On and Off to boolean
+                conversion = localSettings.Values[propertyName] as string;
+                if (conversion == "On")
+                {
+                    previousSetting = true;
+                }
+                else
+                {
+                    previousSetting = false;
+                }
+            }
             #endregion
 
             //Remove old setting
@@ -113,6 +122,13 @@ namespace QuickPad
         public string DefaultFileType
         {
             get => Get<string>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool AutoSave
+        {
+            get => Get<bool>();
             set => Set(value);
         }
         #endregion

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Windows.Storage;
@@ -16,7 +17,44 @@ namespace QuickPad
             {
                 localSettings.Values.Add(propertyName, GetDefaultValue<T>(propertyName));
             }
+            MigrateSettingFromPreviousVersion<T>(propertyName);
             return (T)localSettings.Values[propertyName];
+        }
+
+        private void MigrateSettingFromPreviousVersion<T>(string propertyName)
+        {
+            if (localSettings.Values[propertyName].GetType() == typeof(T))
+                return;
+            object previousSetting = default;
+            string conversion = "";
+
+            #region Setting conversion
+            if (propertyName == nameof(LaunchMode))
+            {
+                conversion = localSettings.Values[propertyName] as string;
+                if (conversion == "Default")
+                {
+                    previousSetting = AvailableModes.Default;
+                }
+                else if (conversion == "On Top")
+                {
+                    previousSetting = AvailableModes.OnTop;
+                }
+                else if (conversion == "Focus Mode")
+                {
+                    previousSetting = AvailableModes.Focus;
+                }
+            }
+            //else if (propert)
+            //{
+
+            //}
+            #endregion
+
+            //Remove old setting
+            localSettings.Values.Remove(propertyName);
+            //Add new setting
+            localSettings.Values.Add(propertyName, (T)previousSetting);
         }
 
         public static T GetDefaultValue<T>(string propertyName)
@@ -61,7 +99,29 @@ namespace QuickPad
         ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
 
         #region Settings
+        [DefaultValue((int)(AvailableModes.Default))]
+        public int LaunchMode
+        {
+            get => Get<int>();
+            set => Set(value);
+        }
 
+        /// <summary>
+        /// this is to check the default file extension choosen in the save file dialog
+        /// </summary>
+        [DefaultValue(".rtf")]
+        public string DefaultFileType
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
         #endregion
+    }
+
+    public enum AvailableModes
+    {
+        Default, //Full UI with toolbar
+        OnTop, //Compact overlay
+        Focus //Hide toolbar
     }
 }

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -1,0 +1,67 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Windows.Storage;
+
+namespace QuickPad
+{
+    public class Setting : INotifyPropertyChanged
+    {
+        #region Get/Set notification
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public T Get<T>([CallerMemberName]string propertyName = null)
+        {
+            if (!localSettings.Values.ContainsKey(propertyName))
+            {
+                localSettings.Values.Add(propertyName, GetDefaultValue<T>(propertyName));
+            }
+            return (T)localSettings.Values[propertyName];
+        }
+
+        public static T GetDefaultValue<T>(string propertyName)
+        {
+            PropertyInfo[] properties = typeof(Setting).GetProperties();
+            foreach (var property in properties)
+            {
+                if (property.Name != propertyName)
+                    continue;
+                var attrs = property.GetCustomAttributes(true);
+                foreach (object attr in attrs)
+                {
+                    if (attr is DefaultValueAttribute def)
+                    {
+                        return (T)def.Value;
+                    }
+                }
+            }
+            return default(T);
+        }
+
+        public void Set<T>(T value, [CallerMemberName]string propertyName = null)
+        {
+            if (!localSettings.Values.ContainsKey(propertyName))
+            {
+                localSettings.Values.Add(propertyName, value);
+                NotifyPropertyChanged(propertyName);
+                return;
+            }
+            if (!Equals(localSettings.Values[propertyName], value))
+            {
+                localSettings.Values[propertyName] = value;
+                NotifyPropertyChanged(propertyName);
+            }
+        }
+
+        public void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion
+        ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+
+        #region Settings
+
+        #endregion
+    }
+}

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -59,7 +59,7 @@ namespace QuickPad
                     previousSetting = false;
                 }
             }
-            else if (propertyName == nameof(WordWrap))
+            else if (propertyName == nameof(WordWrap) || propertyName == nameof(SpellCheck))
             {
                 //Yes and No to boolean
                 conversion = localSettings.Values[propertyName] as string;
@@ -148,6 +148,13 @@ namespace QuickPad
 
         [DefaultValue(true)]
         public bool WordWrap
+        {
+            get => Get<bool>();
+            set => Set(value);
+        }
+
+        [DefaultValue(true)]
+        public bool SpellCheck
         {
             get => Get<bool>();
             set => Set(value);

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -236,6 +236,14 @@ namespace QuickPad
             set => Set(value);
         }
         #endregion
+
+        #region Font setting
+        public string DefaultFont
+        {
+            get => Get<string>();
+            set => Set(value);
+        }
+        #endregion
     }
 
     public enum AvailableModes

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -292,6 +292,13 @@ namespace QuickPad
                 }
             }
         }
+
+        [DefaultValue(1)]
+        public int NewFileAutoNumber
+        {
+            get => Get<int>();
+            set => Set(value);
+        }
         #endregion
 
         #region Events when setting change
@@ -345,6 +352,21 @@ namespace QuickPad
                 return Visibility.Visible;
             }
             return Visibility.Collapsed;
+        }
+
+        /// <summary>
+        /// Use to convert on XAML & x:Bind from bool (or Boolean) to Visibility
+        /// But instead of true=visible, it opposite
+        /// </summary>
+        /// <param name="input">Any boolean input</param>
+        /// <returns></returns>
+        public static Visibility BoolToVisibilityInvert(bool input)
+        {
+            if (input)
+            {
+                return Visibility.Collapsed;
+            }
+            return Visibility.Visible;
         }
 
         /// <summary>

--- a/Quick Pad/Setting.cs
+++ b/Quick Pad/Setting.cs
@@ -117,19 +117,29 @@ namespace QuickPad
             return default(T);
         }
 
-        public void Set<T>(T value, [CallerMemberName]string propertyName = null)
+        /// <summary>
+        /// Set property to setting and after that send a notification to all property that bind to it
+        /// </summary>
+        /// <typeparam name="T">That property type</typeparam>
+        /// <param name="value">A new value of the setting</param>
+        /// <param name="propertyName">A name of the property that will update, 
+        /// don't have to send it as it automatically get a property name that send it</param>
+        /// <returns>Return a boolean, if the setting has been update and notified will return true, otherwise false</returns>
+        public bool Set<T>(T value, [CallerMemberName]string propertyName = null)
         {
             if (!localSettings.Values.ContainsKey(propertyName))
             {
                 localSettings.Values.Add(propertyName, value);
                 NotifyPropertyChanged(propertyName);
-                return;
+                return true;
             }
             if (!Equals(localSettings.Values[propertyName], value))
             {
                 localSettings.Values[propertyName] = value;
                 NotifyPropertyChanged(propertyName);
+                return true;
             }
+            return false;
         }
 
         public void NotifyPropertyChanged(string propertyName)
@@ -182,7 +192,14 @@ namespace QuickPad
         public ElementTheme Theme
         {
             get => (ElementTheme)Get<int>();
-            set => Set((int)value);
+            set
+            {
+                if (Set((int)value))
+                {
+                    //Send an event the theme has changed
+                    afterThemeChanged?.Invoke(value);
+                }
+            }
         }
 
         [DefaultValue(0)]
@@ -244,7 +261,13 @@ namespace QuickPad
             set => Set(value);
         }
         #endregion
+
+        #region Events when setting change
+        public themeChange afterThemeChanged { get; set; }
+        #endregion
     }
+
+    public delegate void themeChange(ElementTheme to);
 
     public enum AvailableModes
     {

--- a/Quick Pad/Strings/en-US/Resources.resw
+++ b/Quick Pad/Strings/en-US/Resources.resw
@@ -240,26 +240,26 @@
   <data name="ExitFocusMode.Text" xml:space="preserve">
     <value>Exit Focus Mode</value>
   </data>
-  <data name="FontColorBlack.Content" xml:space="preserve">
+  <data name="FontColorBlack" xml:space="preserve">
     <value>Black</value>
   </data>
-  <data name="FontColorLightGreen.Content" xml:space="preserve">
-    <value>Green</value>
-  </data>
-  <data name="FontColorLightPink.Content" xml:space="preserve">
-    <value>Pink</value>
-  </data>
-  <data name="FontColorLightSalmon.Content" xml:space="preserve">
-    <value>Orange</value>
-  </data>
-  <data name="FontColorLightYellow.Content" xml:space="preserve">
-    <value>Yellow</value>
-  </data>
-  <data name="FontColorSkyBlue.Content" xml:space="preserve">
+  <data name="FontColorBlue" xml:space="preserve">
     <value>Blue</value>
   </data>
-  <data name="FontColorWhite.Content" xml:space="preserve">
+  <data name="FontColorGreen" xml:space="preserve">
+    <value>Green</value>
+  </data>
+  <data name="FontColorOrange" xml:space="preserve">
+    <value>Orange</value>
+  </data>
+  <data name="FontColorPink" xml:space="preserve">
+    <value>Pink</value>
+  </data>
+  <data name="FontColorWhite" xml:space="preserve">
     <value>White</value>
+  </data>
+  <data name="FontColorYellow" xml:space="preserve">
+    <value>Yellow</value>
   </data>
   <data name="GeneralAutoSave.Text" xml:space="preserve">
     <value>Auto Save</value>

--- a/Quick Pad/Strings/th-TH/Resources.resw
+++ b/Quick Pad/Strings/th-TH/Resources.resw
@@ -240,27 +240,6 @@
   <data name="VersionFormat" xml:space="preserve">
     <value>เวอร์ชั่น: {0}.{1}.{2}.{3}</value>
   </data>
-  <data name="FontColorBlack.Content" xml:space="preserve">
-    <value>ดำ</value>
-  </data>
-  <data name="FontColorLightGreen.Content" xml:space="preserve">
-    <value>เขียว</value>
-  </data>
-  <data name="FontColorLightPink.Content" xml:space="preserve">
-    <value>ชมพู</value>
-  </data>
-  <data name="FontColorLightSalmon.Content" xml:space="preserve">
-    <value>ส้ม</value>
-  </data>
-  <data name="FontColorLightYellow.Content" xml:space="preserve">
-    <value>เหลือง</value>
-  </data>
-  <data name="FontColorSkyBlue.Content" xml:space="preserve">
-    <value>ฟ้า</value>
-  </data>
-  <data name="FontColorWhite.Content" xml:space="preserve">
-    <value>ขาว</value>
-  </data>
   <data name="LaunchModeDefault.Content" xml:space="preserve">
     <value>ปกติ</value>
   </data>
@@ -365,5 +344,32 @@
   </data>
   <data name="JustifyTooltip.Text" xml:space="preserve">
     <value>จัดกลาง (Ctrl+J)</value>
+  </data>
+  <data name="BlackPlaceholder" xml:space="preserve">
+    <value>Black</value>
+  </data>
+  <data name="WhitePlaceholder" xml:space="preserve">
+    <value>ขาว</value>
+  </data>
+  <data name="FontColorBlack" xml:space="preserve">
+    <value>ดำ</value>
+  </data>
+  <data name="FontColorBlue" xml:space="preserve">
+    <value>น้ำเงิน</value>
+  </data>
+  <data name="FontColorGreen" xml:space="preserve">
+    <value>เขียว</value>
+  </data>
+  <data name="FontColorOrange" xml:space="preserve">
+    <value>ส้ม</value>
+  </data>
+  <data name="FontColorPink" xml:space="preserve">
+    <value>ชมพู</value>
+  </data>
+  <data name="FontColorWhite" xml:space="preserve">
+    <value>ขาว</value>
+  </data>
+  <data name="FontColorYellow" xml:space="preserve">
+    <value>เหลือง</value>
   </data>
 </root>


### PR DESCRIPTION
### Instead of checking the ApplicationDataContainer every time for a new setting, bind it directly through Setting helper.

This should prevent an instant of writing wrong setting on localsetting.Value["Something"] and have a misspell on "Something" 

#### What this Setting helper do?

- Get the setting from ApplicationDataContainer
- Update the previous setting which is string base to proper value like DefaultFontSize should store in number
- Provide default value for new setting
- Set a value back into ApplicationDataContainer and send alert to UI to update the value
- Gave some delegate event for a setting that need to do UI update outside Setting class

#### Noticeable change

- Add "Default" option on Default color option
- The item inside Defailt font color has a color preview in front of it

#### Back-end change

- ApplicationDataContainer has been removed from Main.xaml.cs
- Default font color ComboBox has been changed from <ComboBoxItem/> to <DataTemplate/> which allow to add more color easily
- Main.xaml.cs code has been sort in `#region` which can be Collapsed and Expand 
- Title bar text has been change to other string and it will automatically update when it get change
- Lots of setting will now refer to QSetting (Stand for QuickPad setting)
- Font list will only load once and automatically add to two different ComboBox via x:Bind on ItemsSource
- etc..