### PR TITLE
A fix on saving dialog

### DIFF
--- a/Quick Pad/MainPage.xaml.cs
+++ b/Quick Pad/MainPage.xaml.cs
@@ -566,7 +566,7 @@ namespace Quick_Pad_Free_Edition
                 savePicker.FileTypeChoices.Add("All Files", new List<string>() { "." });
 
                 // Default file name if the user does not type one in or select a file to replace
-                savePicker.SuggestedFileName = $"{CurrentFilename}{QSetting.NewFileAutoNumber}";
+                savePicker.SuggestedFileName = $"{_file_name}{QSetting.NewFileAutoNumber}";
 
                 Windows.Storage.StorageFile file = await savePicker.PickSaveFileAsync();
                 if (file != null)


### PR DESCRIPTION
The saved file suggesting with * causing the file to start with _ on saving dialog