### PR TITLE
fix multiline tabbing, add untab

### DIFF
--- a/src/QuickPad.Standard.Mvvm/ViewModels/DocumentViewModel.cs
+++ b/src/QuickPad.Standard.Mvvm/ViewModels/DocumentViewModel.cs
@@ -195,17 +195,17 @@ namespace QuickPad.Mvvm.ViewModels
                 
                 if (SelectedText.Length > 0)
                 {
-                    var Text = SelectedText;
-                    Text = Regex.Replace(Text, "^\r", "");
-                    var TextArray = Text.Split('\r');
-                    for (var i = 0; i < TextArray.Length; i++)
+                    var text = SelectedText;
+                    text = Regex.Replace(text, "^\r", "");
+                    var textArray = text.Split('\r');
+                    for (var i = 0; i < textArray.Length; i++)
                     {
-                        if (TextArray[i].Length > 0)
+                        if (textArray[i].Length > 0)
                         {
-                            TextArray[i] = "\t" + TextArray[i];
+                            textArray[i] = "\t" + textArray[i];
                         }
                     }
-                    SelectedText = string.Join("\r", TextArray);
+                    SelectedText = string.Join("\r", textArray);
                 }
             }
             else
@@ -215,18 +215,51 @@ namespace QuickPad.Mvvm.ViewModels
             }
         }
 
+        public string AddTab(string RTFText)
+        {
+            var textArray = RTFText.Split('\n');
+            if (textArray.Length > 3) //RTF output has 2 metadata lines preceding actual text
+            {
+                for (var i = 2; i < textArray.Length; i++)
+                {
+                    if (!Regex.IsMatch(textArray[i], "^\0$"))
+                    {
+                        textArray[i] = @"\tab " + textArray[i];
+                        textArray[i] = Regex.Replace(textArray[i], @"\\line([\S]*) ", "\\line$1\\tab ");
+                    }
+                }
+            }
+            return string.Join("\n", textArray);
+        }
         public void RemoveTab()
         {
             // Remove tab
             if (SelectedText.Length > 0)
             {
-                var TextArray = SelectedText.Split('\r');
-                for (var i = 0; i < TextArray.Length; i++)
+                var text = SelectedText;
+                var textArray = text.Split('\r');
+                for (var i = 0; i < textArray.Length; i++)
                 {
-                    TextArray[i] = Regex.Replace(TextArray[i], "^\t", "");
+                    textArray[i] = Regex.Replace(textArray[i], "^\t", "");
                 }
-                SelectedText = string.Join("\r", TextArray);
+                SelectedText = string.Join("\r", textArray);
             }
+        }
+
+        public string RemoveTab(string RTFText)
+        {
+            var textArray = RTFText.Split('\n');
+            if (textArray.Length > 3) //RTF output has 2 metadata lines preceding actual text
+            {
+                for (var i = 2; i < textArray.Length; i++)
+                {
+                    if (!Regex.IsMatch(textArray[i], "^\0$"))
+                    {
+                        textArray[i] = Regex.Replace(textArray[i], @"(^|\\par|\\line)([\S]*)\\tab", "$1$2");
+                    }
+                }
+            }
+            return string.Join("\n", textArray);
         }
 
         public string IsDirtyMarker => $"{((Document?.IsDirty ?? false) ? "*" : "")}".Trim();

--- a/src/QuickPad.Standard.Mvvm/ViewModels/DocumentViewModel.cs
+++ b/src/QuickPad.Standard.Mvvm/ViewModels/DocumentViewModel.cs
@@ -7,6 +7,7 @@ using QuickPad.Standard.Data;
 using System;
 using System.ComponentModel;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace QuickPad.Mvvm.ViewModels
@@ -186,16 +187,45 @@ namespace QuickPad.Mvvm.ViewModels
             // Add tab
             if (SelectedText.Length > 0)
             {
-                var currentPosition = CurrentPosition;
-                var text = '\t' + SelectedText;
-                text = text.Replace("\r", "\r\t").TrimEnd('\t');
-                SelectedText = text;
-                SelectText(currentPosition.start + 1, currentPosition.length);
+                if (SelectedText.StartsWith("\r"))
+                {
+                    var currentPosition = CurrentPosition;
+                    SelectText(currentPosition.start + 1, currentPosition.length - 1);
+                }
+                
+                if (SelectedText.Length > 0)
+                {
+                    var Text = SelectedText;
+                    Text = Regex.Replace(Text, "^\r", "");
+                    var TextArray = Text.Split('\r');
+                    for (var i = 0; i < TextArray.Length; i++)
+                    {
+                        if (TextArray[i].Length > 0)
+                        {
+                            TextArray[i] = "\t" + TextArray[i];
+                        }
+                    }
+                    SelectedText = string.Join("\r", TextArray);
+                }
             }
             else
             {
                 SelectedText = "\t";
                 SelectText(CurrentPosition.start + 1, 0);
+            }
+        }
+
+        public void RemoveTab()
+        {
+            // Remove tab
+            if (SelectedText.Length > 0)
+            {
+                var TextArray = SelectedText.Split('\r');
+                for (var i = 0; i < TextArray.Length; i++)
+                {
+                    TextArray[i] = Regex.Replace(TextArray[i], "^\t", "");
+                }
+                SelectedText = string.Join("\r", TextArray);
             }
         }
 

--- a/src/QuickPad.UI/QuickPad.UI/MainPage.xaml.cs
+++ b/src/QuickPad.UI/QuickPad.UI/MainPage.xaml.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Numerics;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
@@ -26,6 +27,7 @@ using Windows.System;
 using Windows.UI;
 using Windows.UI.Core;
 using Windows.UI.Core.Preview;
+using Windows.UI.Text;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -661,14 +663,45 @@ namespace QuickPad.UI
             {
                 //handle tab spacing
                 case VirtualKey.Tab:
+                    if (ViewModel.IsRtf) //for RTF files, move selection to ignore starting and ending newlines
+                    {
+                        while (Regex.IsMatch(RichEditBox.Document.Selection.Text, "^(\r|\v)"))
+                        {
+                            RichEditBox.Document.Selection.StartPosition++;
+                        }
+                        while (Regex.IsMatch(RichEditBox.Document.Selection.Text, "(\r|\v)$"))
+                        {
+                            RichEditBox.Document.Selection.EndPosition--;
+                        }
+                    }
                     if (Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift)
                         .HasFlag(CoreVirtualKeyStates.Down))
                     {
-                        ViewModel.RemoveTab();
+                        if (ViewModel.IsRtf)
+                        {
+                            string text;
+                            RichEditBox.Document.Selection.GetText(TextGetOptions.FormatRtf, out text);
+                            text = ViewModel.RemoveTab(text);
+                            RichEditBox.Document.Selection.SetText(TextSetOptions.FormatRtf, text);
+                        }
+                        else
+                        {
+                            ViewModel.RemoveTab();
+                        }
                     }
                     else 
                     {
-                        ViewModel.AddTab();
+                        if (ViewModel.IsRtf)
+                        {
+                            string text;
+                            RichEditBox.Document.Selection.GetText(TextGetOptions.FormatRtf, out text);
+                            text = ViewModel.AddTab(text);
+                            RichEditBox.Document.Selection.SetText(TextSetOptions.FormatRtf, text);
+                        }
+                        else
+                        {
+                            ViewModel.AddTab();
+                        }
                     }
                     break;
             }

--- a/src/QuickPad.UI/QuickPad.UI/MainPage.xaml.cs
+++ b/src/QuickPad.UI/QuickPad.UI/MainPage.xaml.cs
@@ -657,12 +657,21 @@ namespace QuickPad.UI
 
         private void Text_OnKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            //add tab space
-            if (e.Key != VirtualKey.Tab || Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift)
-                    .HasFlag(CoreVirtualKeyStates.Down)) return;
-
-            ViewModel.AddTab();
-
+            switch (e.Key)
+            {
+                //handle tab spacing
+                case VirtualKey.Tab:
+                    if (Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift)
+                        .HasFlag(CoreVirtualKeyStates.Down))
+                    {
+                        ViewModel.RemoveTab();
+                    }
+                    else 
+                    {
+                        ViewModel.AddTab();
+                    }
+                    break;
+            }
             e.Handled = true;
         }
 


### PR DESCRIPTION
Fixes bug where selecting multiple lines and pressing tab causes the selection to shrink. Allows removal of tabs using shift-tab.